### PR TITLE
setText fixed

### DIFF
--- a/aui.views/src/AUI/View/AAbstractTextField.cpp
+++ b/aui.views/src/AUI/View/AAbstractTextField.cpp
@@ -105,9 +105,9 @@ void AAbstractTextField::setText(const AString& t)
 	mContents = t;
     if (t.empty()) {
         clearSelection();
-        mCursorIndex = 0;
     }
 
+    mCursorIndex = t.size();
 	updateCursorBlinking();
 
     invalidatePrerenderedString();

--- a/aui.views/src/AUI/View/AView.h
+++ b/aui.views/src/AUI/View/AView.h
@@ -831,6 +831,8 @@ public:
 
 
 signals:
+    emits<> addedToContainer;
+
     emits<bool> hoveredState;
     emits<> mouseEnter;
     emits<> mouseLeave;

--- a/aui.views/src/AUI/View/AViewContainer.cpp
+++ b/aui.views/src/AUI/View/AViewContainer.cpp
@@ -60,6 +60,7 @@ void AViewContainer::addViews(AVector<_<AView>> views) {
     for (const auto& view: views) {
         view->mParent = this;
         AUI_NULLSAFE(mLayout)->addView(-1, view);
+        emit view->addedToContainer();
     }
 
     if (mViews.empty()) {
@@ -73,12 +74,14 @@ void AViewContainer::addView(const _<AView>& view) {
     mViews << view;
     view->mParent = this;
     AUI_NULLSAFE(mLayout)->addView(-1, view);
+    emit view->addedToContainer();
 }
 
 void AViewContainer::addViewCustomLayout(const _<AView>& view) {
     mViews << view;
     view->mParent = this;
     view->setSize(view->getMinimumSize());
+    emit view->addedToContainer();
 }
 
 void AViewContainer::addView(size_t index, const _<AView>& view) {
@@ -86,6 +89,7 @@ void AViewContainer::addView(size_t index, const _<AView>& view) {
     view->mParent = this;
     if (mLayout)
         mLayout->addView(index, view);
+    emit view->addedToContainer();
 }
 
 void AViewContainer::removeView(const _<AView>& view) {


### PR DESCRIPTION
When setting text, cursor index was not changed, so typing another symbol caused inserting over the bounds of the string