### PR TITLE
AAnimator fix

### DIFF
--- a/aui.views/src/AUI/Animator/AAnimator.cpp
+++ b/aui.views/src/AUI/Animator/AAnimator.cpp
@@ -54,19 +54,26 @@ void AAnimator::pause() {
 }
 
 void AAnimator::translateToCenter() {
-    Render::setTransform(
-            glm::translate(glm::mat4(1.f),
-                           glm::vec3(glm::vec2(mView->getSize().x,
-                                                mView->getSize().y + mView->getTotalFieldVertical() - 1) / 2.f, 0.f)));
+    translateToCenter(mView);
 }
 
 void AAnimator::translateToCorner() {
-    Render::setTransform(
-            glm::translate(glm::mat4(1.f),
-                           glm::vec3(-glm::vec2(mView->getSize().x,
-                                   mView->getSize().y + mView->getTotalFieldVertical() - 1) / 2.f, 0.f)));
+    translateToCorner(mView);
 }
 
+void AAnimator::translateToCenter(AView* view) {
+    Render::setTransform(
+            glm::translate(glm::mat4(1.f),
+                           glm::vec3(glm::vec2(view->getSize().x,
+                                               view->getSize().y + view->getTotalFieldVertical() - 1) / 2.f, 0.f)));
+}
+
+void AAnimator::translateToCorner(AView* view) {
+    Render::setTransform(
+            glm::translate(glm::mat4(1.f),
+                           glm::vec3(-glm::vec2(view->getSize().x,
+                                                view->getSize().y + view->getTotalFieldVertical() - 1) / 2.f, 0.f)));
+}
 
 _<AAnimator> AAnimator::combine(const AVector<_<AAnimator>>& animators) {
     class ACombiningAnimator: public AAnimator {

--- a/aui.views/src/AUI/Animator/AAnimator.h
+++ b/aui.views/src/AUI/Animator/AAnimator.h
@@ -88,6 +88,9 @@ protected:
     void translateToCenter();
     void translateToCorner();
 
+    static void translateToCenter(AView* view);
+    static void translateToCorner(AView* view);
+
 public:
 
     void setCurve(const std::function<float(float)>& curve) {
@@ -114,7 +117,5 @@ public:
         mView = view;
     }
 
-
     static _<AAnimator> combine(const AVector<_<AAnimator>>& animators);
 };
-

--- a/aui.views/src/AUI/Animator/ARotationAnimator.cpp
+++ b/aui.views/src/AUI/Animator/ARotationAnimator.cpp
@@ -23,9 +23,9 @@
 
 void ARotationAnimator::doAnimation(AView* view, float theta) {
 
-    translateToCenter();
+    translateToCenter(view);
     Render::setTransform(
             glm::rotate(glm::mat4(1.f), theta * 2 * glm::pi<float>(), glm::vec3{0.f, 0.f, 1.f}));
-    translateToCorner();
+    translateToCorner(view);
 
 }


### PR DESCRIPTION
The problem arised when combining animators that use `translateToCorner` or `translateToCenter`. These methods use mView field, which is null when not setting animator itself but only calling `animate`.