### PR TITLE
Little updates in `core`, `views`, and `json` modules

### DIFF
--- a/aui.core/src/AUI/Common/AContainerPrototypes.h
+++ b/aui.core/src/AUI/Common/AContainerPrototypes.h
@@ -22,5 +22,8 @@
 template <class KeyType, class ValueType, class Predicate = std::less<KeyType>, class Allocator = std::allocator<std::pair<const KeyType, ValueType>>>
 class AMap;
 
+template <class KeyType, class ValueType, class Hasher = std::hash<KeyType>, class Comparer = std::equal_to<KeyType>, class Allocator = std::allocator<std::pair<const KeyType, ValueType>>>
+class AUnorderedMap;
+
 template <class StoredType, class Allocator = std::allocator<StoredType>>
 class AVector;

--- a/aui.core/src/AUI/Common/AMap.h
+++ b/aui.core/src/AUI/Common/AMap.h
@@ -16,6 +16,7 @@
 
 #pragma once
 #include <map>
+#include <unordered_map>
 #include "AUI/Core.h"
 #include "AException.h"
 #include <AUI/Common/AVector.h>
@@ -24,37 +25,36 @@
 #include "AContainerPrototypes.h"
 
 /**
- * @brief A std::map with AUI extensions.
+ * @brief Base class for maps with AUI extensions.
  * @ingroup core
  */
-template <class KeyType, class ValueType, class Predicate, class Allocator>
-class AMap: public std::map<KeyType, ValueType, Predicate, Allocator>
+template <class KeyType, class ValueType, class Parent>
+class ABaseMap: public Parent
 {
 public:
-	using parent = std::map<KeyType, ValueType, Predicate, Allocator>;
-	using iterator = typename parent::iterator;
-	using const_iterator = typename parent::const_iterator;
+	using iterator = typename Parent::iterator;
+	using const_iterator = typename Parent::const_iterator;
 
-	using parent::parent;
+	using Parent::Parent;
 
 	ValueType& operator[](KeyType&& k)
 	{
-		return parent::operator[](std::forward<KeyType>(k));
+		return Parent::operator[](std::forward<KeyType>(k));
 	}
 
 	ValueType& operator[](const KeyType& k)
 	{
-		return parent::operator[](k);
+		return Parent::operator[](k);
 	}
 
 	const ValueType& operator[](KeyType&& k) const
 	{
-		return parent::at(std::forward<KeyType>(k));
+		return Parent::at(std::forward<KeyType>(k));
 	}
 
 	const ValueType& operator[](const KeyType& k) const
 	{
-		return parent::at(k);
+		return Parent::at(k);
 	}
 
 	// ================
@@ -127,14 +127,14 @@ public:
 	};
 
 	ValueType& at(const KeyType& key) {
-	    auto it = parent::find(key);
-	    if (it == parent::end())
+	    auto it = Parent::find(key);
+	    if (it == Parent::end())
 	        throw AException("no such element: " + AClass<KeyType>::toString(key));
 	    return it->second;
 	}
 	const ValueType& at(const KeyType& key) const {
-	    auto it = parent::find(key);
-	    if (it == parent::end())
+	    auto it = Parent::find(key);
+	    if (it == Parent::end())
 	        throw AException("no such element: " + AClass<KeyType>::toString(key));
 	    return it->second;
 	}
@@ -142,21 +142,21 @@ public:
     [[nodiscard]]
 	const_contains_iterator contains(const KeyType& key) const noexcept
 	{
-		auto it = parent::find(key);
-		return const_contains_iterator(it, it != parent::end());
+		auto it = Parent::find(key);
+		return const_contains_iterator(it, it != Parent::end());
 	}
 
     [[nodiscard]]
     contains_iterator contains(const KeyType& key) noexcept
 	{
-		auto it = parent::find(key);
-		return contains_iterator(it, it != parent::end());
+		auto it = Parent::find(key);
+		return contains_iterator(it, it != Parent::end());
 	}
 
     [[nodiscard]]
     AOptional<ValueType> optional(const KeyType& key) const noexcept {
-        auto it = parent::find(key);
-        if (it == parent::end()) {
+        auto it = Parent::find(key);
+        if (it == Parent::end()) {
             return std::nullopt;
         }
         return it->second;
@@ -164,7 +164,7 @@ public:
 
 	AVector<KeyType> keyVector() {
         AVector<KeyType> r;
-        r.reserve(parent::size());
+        r.reserve(Parent::size());
         for (auto& p : *this) {
             r << p.first;
         }
@@ -172,7 +172,7 @@ public:
 	}
 	AVector<ValueType> valueVector() {
         AVector<ValueType> r;
-        r.reserve(parent::size());
+        r.reserve(Parent::size());
         for (auto& p : *this) {
             r << p.second;
         }
@@ -189,8 +189,8 @@ public:
     template<typename Factory>
     ValueType& getOrInsert(const KeyType& keyType, Factory&& factory) noexcept(noexcept(factory())) {
         static_assert(std::is_constructible_v<ValueType>, "ValueType is expected to be default-constructible");
-        auto[it, isElementCreated] = parent::insert(typename parent::value_type(keyType, ValueType{}));
-        static_assert(std::is_same_v<decltype(it), typename parent::iterator>, "govno");
+        auto[it, isElementCreated] = Parent::insert(typename Parent::value_type(keyType, ValueType{}));
+        static_assert(std::is_same_v<decltype(it), typename Parent::iterator>, "govno");
         if (isElementCreated) {
             it->second = factory();
         }
@@ -200,8 +200,8 @@ public:
     template<typename BinaryOperation>
     auto toVector(BinaryOperation&& transformer) const -> AVector<decltype(transformer(std::declval<KeyType>(), std::declval<ValueType>()))> {
         AVector<decltype(transformer(std::declval<KeyType>(), std::declval<ValueType>()))> result;
-        result.reserve(parent::size());
-        std::transform(parent::begin(), parent::end(), std::back_inserter(result), [transformer = std::forward<BinaryOperation>(transformer)](const typename parent::value_type& p){
+        result.reserve(Parent::size());
+        std::transform(Parent::begin(), Parent::end(), std::back_inserter(result), [transformer = std::forward<BinaryOperation>(transformer)](const typename Parent::value_type& p){
             return transformer(p.first, p.second);
         });
         return result;
@@ -214,6 +214,29 @@ public:
     }
 };
 
+/**
+ * @brief A std::map with AUI extensions.
+ * @ingroup core
+ */
+template <class KeyType, class ValueType, class Predicate, class Allocator>
+class AMap: public ABaseMap<KeyType, ValueType, std::map<KeyType, ValueType, Predicate, Allocator>>
+{
+	using parent = ABaseMap<KeyType, ValueType, std::map<KeyType, ValueType, Predicate, Allocator>>;
+
+	using parent::parent;
+};
+
+/**
+ * @brief A std::unordered_map with AUI extensions.
+ * @ingroup core
+ */
+template <class KeyType, class ValueType, class Hasher, class Comparer, class Allocator>
+class AUnorderedMap: public ABaseMap<KeyType, ValueType, std::unordered_map<KeyType, ValueType, Hasher, Comparer, Allocator>>
+{
+	using parent = ABaseMap<KeyType, ValueType, std::unordered_map<KeyType, ValueType, Hasher, Comparer, Allocator>>;
+
+	using parent::parent;
+};
 
 template<typename Iterator, typename UnaryOperation>
 inline auto aui::container::to_map(Iterator begin,
@@ -221,6 +244,20 @@ inline auto aui::container::to_map(Iterator begin,
                                    UnaryOperation&& transformer) {
     AMap<decltype(transformer(*begin).first),
          decltype(transformer(*begin).second)> result;
+
+    for (auto it = begin; it != end; ++it) {
+        auto[key, value] = transformer(*it);
+        result[std::move(key)] = std::move(value);
+    }
+    return result;
+}
+
+template<typename Iterator, typename UnaryOperation>
+inline auto aui::container::to_unordered_map(Iterator begin,
+                                             Iterator end,
+                                             UnaryOperation&& transformer) {
+    AUnorderedMap<decltype(transformer(*begin).first),
+                  decltype(transformer(*begin).second)> result;
 
     for (auto it = begin; it != end; ++it) {
         auto[key, value] = transformer(*it);

--- a/aui.core/src/AUI/Model/ATreeModelIndex.h
+++ b/aui.core/src/AUI/Model/ATreeModelIndex.h
@@ -58,6 +58,14 @@ public:
         return mColumn;
     }
 
+    /**
+     * @brief check if this vertex is the root.
+     */
+    [[nodiscard]]
+    bool isRoot() const noexcept {
+        return mRow == 0 && mColumn == 0;
+    }
+
 private:
     std::size_t mRow;
     std::size_t mColumn;

--- a/aui.core/src/AUI/Traits/containers.h
+++ b/aui.core/src/AUI/Traits/containers.h
@@ -222,6 +222,14 @@ namespace aui::container {
     auto to_map(Iterator begin, Iterator end, UnaryOperation&& transformer); // implemented in AMap.h
 
     /**
+     * @brief Transforms sequence to unordered_map.
+     * @ingroup core
+     */
+    template<typename Iterator, typename UnaryOperation>
+    [[nodiscard]]
+    auto to_unordered_map(Iterator begin, Iterator end, UnaryOperation&& transformer); // implemented in AUnorderedMap.h
+
+    /**
      * @ingroup core
      * @return true if <code>r</code> container is a subset of <code>l</code> container, false otherwise.
      */

--- a/aui.json/src/AUI/Json/AJson.h
+++ b/aui.json/src/AUI/Json/AJson.h
@@ -32,7 +32,7 @@
 
 class AJson;
 namespace aui::impl {
-    using JsonObject = AMap<AString, AJson>;
+    using JsonObject = AUnorderedMap<AString, AJson>;
     using JsonArray = AVector<AJson>;
     using JsonVariant = std::variant<std::nullopt_t, std::nullptr_t, int, int64_t, double, bool, AString, aui::impl::JsonArray, aui::impl::JsonObject>;
 }

--- a/aui.views/src/AUI/Image/AAnimatedDrawable.h
+++ b/aui.views/src/AUI/Image/AAnimatedDrawable.h
@@ -24,7 +24,7 @@
 #include "AUI/Render/ARender.h"
 #include "AUI/Common/ASignal.h"
 
-class AAnimatedDrawable : public IDrawable, public AObject {
+class API_AUI_VIEWS AAnimatedDrawable : public IDrawable, public AObject {
 private:
     _<IAnimatedImageFactory> mFactory;
     _<ITexture> mTexture;

--- a/aui.views/src/AUI/Image/AVectorDrawable.h
+++ b/aui.views/src/AUI/Image/AVectorDrawable.h
@@ -24,7 +24,7 @@
 #include "AUI/Render/ARender.h"
 
 
-class AVectorDrawable: public IDrawable
+class API_AUI_VIEWS AVectorDrawable: public IDrawable
 {
 private:
     struct Pair {

--- a/aui.views/src/AUI/Platform/AWindows.cpp
+++ b/aui.views/src/AUI/Platform/AWindows.cpp
@@ -42,6 +42,7 @@ bool AWindow::consumesClick(const glm::ivec2& pos) {
 }
 
 void AWindow::onClosed() {
+    emit closed();
     quit();
 }
 
@@ -181,7 +182,7 @@ void AWindow::flagUpdateLayout() {
 
 
 void AWindow::onCloseButtonClicked() {
-    emit closed();
+    close();
 }
 
 
@@ -222,8 +223,6 @@ void AWindow::windowNativePreInit(const AString& name, int width, int height, AW
     mSize = (glm::max)(glm::ivec2{ width, height }, getMinimumSize());
 
     currentWindowStorage() = this;
-
-    connect(closed, this, &AWindow::close);
 
     getWindowManager().initNativeWindow({ *this, name, width, height, ws, parent });
 

--- a/aui.views/src/AUI/Util/Declarative.h
+++ b/aui.views/src/AUI/Util/Declarative.h
@@ -140,7 +140,7 @@ namespace aui::ui_building {
             }, std::forward<Views>(views)...);
         }
 
-        ViewContainer operator()() {
+        _<Container> operator()() {
             auto c = _new<Container>();
             if constexpr(!std::is_same_v<Layout, std::nullopt_t>) {
                 c->setLayout(_new<Layout>());
@@ -164,7 +164,7 @@ namespace aui::ui_building {
 
             }
 
-            ViewContainer operator()() {
+            _<Container> operator()() {
                 return layouted_container_factory_impl<Layout>::operator()() let {
                     it->setExpanding();
                 };

--- a/aui.views/src/AUI/View/ANumberPicker.cpp
+++ b/aui.views/src/AUI/View/ANumberPicker.cpp
@@ -81,7 +81,7 @@ ANumberPicker::ANumberPicker()
 
 	connect(mTextField->textChanged, this, [&]()
 	{
-		int v = getValue();
+		int64_t v = getValue();
 		if (v < mMin)
 		{
 			v = mMin;
@@ -114,25 +114,25 @@ int ANumberPicker::getContentMinimumHeight(ALayoutDirection layout)
 	return AViewContainer::getContentMinimumHeight(ALayoutDirection::NONE);
 }
 
-void ANumberPicker::setValue(int v)
+void ANumberPicker::setValue(int64_t v)
 {
 	mTextField->setText(AString::number(v));
     redraw();
 }
 
-int ANumberPicker::getValue() const
+int64_t ANumberPicker::getValue() const
 {
 	return mTextField->text().toInt().valueOr(0);
 }
 
-void ANumberPicker::setMin(int min)
+void ANumberPicker::setMin(int64_t min)
 {
 	mMin = min;
 	if (getValue() < min)
 		setValue(min);
 }
 
-void ANumberPicker::setMax(int max)
+void ANumberPicker::setMax(int64_t max)
 {
 	mMax = max;
 	if (getValue() > max)
@@ -148,7 +148,7 @@ void ANumberPicker::decrease() {
     changeBy(AInput::isKeyDown(AInput::LCONTROL) ? -10 : -1);
 }
 
-void ANumberPicker::changeBy(int v) {
+void ANumberPicker::changeBy(int64_t v) {
     setValue(getValue() + v);
     emit valueChanging();
 }

--- a/aui.views/src/AUI/View/ANumberPicker.h
+++ b/aui.views/src/AUI/View/ANumberPicker.h
@@ -46,16 +46,16 @@ private:
 
     _<ANumberPickerField> mTextField;
 
-    int mMin = 0;
-    int mMax = 100;
+    int64_t mMin = 0;
+    int64_t mMax = 100;
 
 public:
     ANumberPicker();
 
     int getContentMinimumHeight(ALayoutDirection layout) override;
 
-    void setValue(int v);
-    int getValue() const;
+    void setValue(int64_t v);
+    int64_t getValue() const;
 
     [[nodiscard]]
     const AString& text() const noexcept {
@@ -64,28 +64,28 @@ public:
 
     void increase();
     void decrease();
-    void changeBy(int v);
+    void changeBy(int64_t v);
 
 
-    [[nodiscard]] int getMin() const
+    [[nodiscard]] int64_t getMin() const
     {
         return mMin;
     }
 
-    [[nodiscard]] int getMax() const
+    [[nodiscard]] int64_t getMax() const
     {
         return mMax;
     }
 
 
-    void setMin(int min);
-    void setMax(int max);
+    void setMin(int64_t min);
+    void setMax(int64_t max);
 
 signals:
     /**
      * @brief Number changed.
      */
-    emits<int> valueChanged;
+    emits<int64_t> valueChanged;
 
     /**
      * @brief Number is changing.
@@ -99,8 +99,8 @@ namespace aui::impl {
     public:
 
         static void setup(const _<ANumberPicker>& view) {
-            view->setMin((std::numeric_limits<int>::min)());
-            view->setMax((std::numeric_limits<int>::max)());
+            view->setMin((std::numeric_limits<Num>::min)());
+            view->setMax((std::numeric_limits<Num>::max)());
         }
 
         static auto getGetter() {
@@ -119,4 +119,4 @@ template<> struct ADataBindingDefault<ANumberPicker, uint16_t>: aui::impl::AData
 template<> struct ADataBindingDefault<ANumberPicker, int16_t>: aui::impl::ADataBindingDefaultNumberPicker<int16_t> {};
 template<> struct ADataBindingDefault<ANumberPicker, uint32_t>: aui::impl::ADataBindingDefaultNumberPicker<uint32_t> {};
 template<> struct ADataBindingDefault<ANumberPicker, int32_t>: aui::impl::ADataBindingDefaultNumberPicker<int32_t> {};
-
+template<> struct ADataBindingDefault<ANumberPicker, int64_t>: aui::impl::ADataBindingDefaultNumberPicker<int64_t> {};

--- a/aui.views/src/AUI/View/ARadioButton.cpp
+++ b/aui.views/src/AUI/View/ARadioButton.cpp
@@ -86,6 +86,7 @@ int ARadioButton::Group::getSelectedId() const {
 }
 
 void ARadioButton::Group::setSelectedId(int id) {
+    if (mSelectedId == id) return;
     mSelectedId = id;
     mButtons[id]->setChecked(true);
 }

--- a/aui.views/src/AUI/View/ARadioGroup.cpp
+++ b/aui.views/src/AUI/View/ARadioGroup.cpp
@@ -49,3 +49,7 @@ void ARadioGroup::setModel(const _<IListModel<AString>>& model) {
 
     requestLayoutUpdate();
 }
+
+void ARadioGroup::setSelectedId(int id) const {
+    mGroup->setSelectedId(id);
+}

--- a/aui.views/src/AUI/View/ARadioGroup.cpp
+++ b/aui.views/src/AUI/View/ARadioGroup.cpp
@@ -23,6 +23,12 @@
 #include <AUI/Platform/AWindow.h>
 
 
+ARadioGroup::ARadioGroup() : mGroup(_new<ARadioButton::Group>()) {
+    connect(mGroup->selectionChanged, this, [&](const AListModelIndex& index) {
+        emit selectionChanged(index);
+    });
+}
+
 ARadioGroup::~ARadioGroup() {
 
 }

--- a/aui.views/src/AUI/View/ARadioGroup.cpp
+++ b/aui.views/src/AUI/View/ARadioGroup.cpp
@@ -18,7 +18,6 @@
 // Created by alex2 on 21.09.2020.
 //
 
-#include <AUI/Layout/AVerticalLayout.h>
 #include "ARadioGroup.h"
 #include "ARadioButton.h"
 #include <AUI/Platform/AWindow.h>
@@ -30,7 +29,6 @@ ARadioGroup::~ARadioGroup() {
 
 void ARadioGroup::setModel(const _<IListModel<AString>>& model) {
     mModel = model;
-    setLayout(_new<AVerticalLayout>());
 
     if (mModel) {
         for (size_t i = 0; i < model->listSize(); ++i) {

--- a/aui.views/src/AUI/View/ARadioGroup.h
+++ b/aui.views/src/AUI/View/ARadioGroup.h
@@ -65,6 +65,7 @@ public:
     [[nodiscard]] int getSelectedId() const {
         return mGroup->getSelectedId();
     }
+    void setSelectedId(int id) const;
 
 signals:
     emits<AListModelIndex> selectionChanged;

--- a/aui.views/src/AUI/View/ARadioGroup.h
+++ b/aui.views/src/AUI/View/ARadioGroup.h
@@ -23,7 +23,8 @@
 #include "AViewContainer.h"
 #include "ARadioButton.h"
 #include "AUI/Model/AListModel.h"
-#include "AUI/Layout/AVerticalLayout.h"
+#include <AUI/Layout/AHorizontalLayout.h>
+#include <AUI/Layout/AVerticalLayout.h>
 #include <AUI/Model/IListModel.h>
 
 /**
@@ -40,15 +41,21 @@ private:
 
 public:
     template<typename... RadioButtons>
-    explicit ARadioGroup(RadioButtons&&... radioButtons): mGroup(_new<ARadioButton::Group>()) {
+    explicit ARadioGroup(RadioButtons&&... radioButtons): ARadioGroup() {
         setLayout(_new<AVerticalLayout>());
-        aui::parameter_pack::for_each([&](const _<ARadioButton>& v) {
-            mGroup->addRadioButton(v);
-            addView(v);
-        }, std::forward<RadioButtons>(radioButtons)...);
+        setViews({ std::forward<RadioButtons>(radioButtons)... });
     }
-    ARadioGroup();
+    ARadioGroup(): mGroup(_new<ARadioButton::Group>()) {}
     ~ARadioGroup() override;
+
+    void setViews(AVector<_<AView>> views) {
+        for (const _<AView>& v : views) {
+            if (auto rb = _cast<ARadioButton>(v)) {
+                mGroup->addRadioButton(rb);
+                addView(v);
+            }
+        }
+    }
 
     void setModel(const _<IListModel<AString>>& model);
 
@@ -65,9 +72,10 @@ signals:
 
 
 namespace declarative {
-    struct RadioGroup: aui::ui_building::view<ARadioGroup> {
-    public:
-        using view<ARadioGroup>::view;
-
+    struct RadioGroup: aui::ui_building::layouted_container_factory<AVerticalLayout, ARadioGroup> {
+        using aui::ui_building::layouted_container_factory<AVerticalLayout, ARadioGroup>::layouted_container_factory;
+        struct Horizontal: aui::ui_building::layouted_container_factory<AHorizontalLayout, ARadioGroup> {
+            using aui::ui_building::layouted_container_factory<AHorizontalLayout, ARadioGroup>::layouted_container_factory;
+        };
     };
 }

--- a/aui.views/src/AUI/View/ARadioGroup.h
+++ b/aui.views/src/AUI/View/ARadioGroup.h
@@ -45,7 +45,7 @@ public:
         setLayout(_new<AVerticalLayout>());
         setViews({ std::forward<RadioButtons>(radioButtons)... });
     }
-    ARadioGroup(): mGroup(_new<ARadioButton::Group>()) {}
+    ARadioGroup();
     ~ARadioGroup() override;
 
     void setViews(AVector<_<AView>> views) {


### PR DESCRIPTION
Hey @Alex2772,

Finally opened the promised PR. There is an highlight of the most notable updates:

## Allowed RadioGroup view to have horizontal layout

Actually `RadioGroup` only display vertically. For UI sake I had to display it horizontally in my app. The change I did are not breaking since the default behavior is the vertical display, and the API is similar to `ASplitter`:

```cpp
// Display a vertical radio group, same as before
RadioGroup {
  RadioButton { "Choice 1" },
  RadioButton { "Choice 2" }
}

// Display an horizontal radio group
RadioGroup::Horizontal {
  RadioButton { "Choice 1" },
  RadioButton { "Choice 2" }
}
```

## Added support for 64-bit integers in ANumberPicker

I don't know if there was a restriction to only use 32-bit integers, but I extended the view to support 64-bit integers and it still work correctly.

## Added ability to set the selected item in RadioGroup

I've just added a `void setSelectedId(int id)` method in the `ARadioGroup` view, to programmatically set the active radio button. This was needed when my app initializes to display the loaded settings.

## Emit `closed` signal when programmatically closing a window

I discovered that when a window was programmatically closed, it was not emitting the `closed` signal. I don't know if it was a technical choice.

## Added and used `AUnorderedMap` on json objects

JSON object was using `AMap`, which was reordering keys of JSON data. For my use case (and I think for many others) reordering keys was breaking a lot of things, because the JSON I'm manipulating are intended to be used in other tools/platforms (mostly games) were the order of keys matter a lot for performance purposes. So to avoid this I had to create a `AUnorderedMap` following the `AMap` implementation, and I used that class as the alias of `AJson::Object`. With that everything works well for me now.

## TreeView data insertion, update and removal was not working properly

I had to make some updates in the `ATreeView` where the `dataInserted`, `dataRemoved` and `dataChanged` signals were not working (at least for my case), and the `dataChanged` signal was not handled at all. I have a multi-level tree view in my app (which represent a file tree like in Visual Studio Code) and when files got updated/added/removed the file tree was not updated correctly, some times items got duplicated and other times everything got cleared.

With the changes I made things are working correctly now, but I feel things may be implemented better so your advice on that will help.
