### PR TITLE
Few UI and usability updates

### DIFF
--- a/aui.json/src/AUI/Json/Conversion.h
+++ b/aui.json/src/AUI/Json/Conversion.h
@@ -97,7 +97,7 @@ namespace aui::impl::json {
 
         void operator()(const AJson::Object& object) {
             if (auto c = object.contains(name)) {
-                value = aui::from_json<T>(c->second);
+                aui::from_json<T>(c->second, value);
             } else {
                 if (!(flags & AJsonFieldFlags::OPTIONAL)) {
                     throw AJsonException(R"(field "{}" is not present)"_format(name));

--- a/aui.views/src/AUI/Action/AMenu.h
+++ b/aui.views/src/AUI/Action/AMenu.h
@@ -31,7 +31,7 @@ struct AMenuItem;
 
 using AMenuModel = AVector<AMenuItem>;
 
-class AMenu {
+class API_AUI_VIEWS AMenu {
 private:
     static _<IMenuProvider>& provider();
 public:

--- a/aui.views/src/AUI/Platform/ACustomWindow.h
+++ b/aui.views/src/AUI/Platform/ACustomWindow.h
@@ -23,6 +23,7 @@ class API_AUI_VIEWS ACustomWindow: public AWindow
 {
 private:
     bool mDragging = false;
+    uint32_t mTitleHeight = 30;
 
 protected:
 	LRESULT winProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) noexcept override;
@@ -32,7 +33,12 @@ public:
 	ACustomWindow(const AString& name, int width, int height);
 	ACustomWindow();
 	~ACustomWindow() override;
-	void setSize(glm::ivec2 size) override;
+
+    void setTitleHeight(uint32_t height) {
+        mTitleHeight = height;
+    }
+
+    void setSize(glm::ivec2 size) override;
 
 	virtual bool isCaptionAt(const glm::ivec2& pos);
 
@@ -48,6 +54,7 @@ class API_AUI_VIEWS ACustomWindow: public AWindow
 private:
     bool mDragging = false;
     glm::ivec2 mDragPos;
+    uint32_t mTitleHeight = 30;
 
     void handleXConfigureNotify();
 
@@ -55,6 +62,10 @@ public:
     ACustomWindow(const AString& name, int width, int height);
     ACustomWindow() = default;
     ~ACustomWindow() override = default;
+
+    void setTitleHeight(uint32_t height) {
+        mTitleHeight = height;
+    }
 
     void onPointerPressed(const APointerPressedEvent& event) override;
     void onPointerReleased(const APointerReleasedEvent& event) override;

--- a/aui.views/src/AUI/Platform/AMessageBox.h
+++ b/aui.views/src/AUI/Platform/AMessageBox.h
@@ -35,6 +35,7 @@ namespace AMessageBox
 		OK,
 		OK_CANCEL,
 		YES_NO,
+		YES_NO_CANCEL,
 	};
 	enum class ResultButton
 	{

--- a/aui.views/src/AUI/Platform/AOverlappingSurface.h
+++ b/aui.views/src/AUI/Platform/AOverlappingSurface.h
@@ -41,6 +41,10 @@ public:
         mCloseOnClick = closeOnClick;
     }
 
+    ABaseWindow* getParentWindow() const {
+        return mParentWindow;
+    }
+
     virtual void setOverlappingSurfacePosition(glm::ivec2 position) = 0;
     virtual void setOverlappingSurfaceSize(glm::ivec2 size) = 0;
 };

--- a/aui.views/src/AUI/Platform/android/ACustomWindowImpl.cpp
+++ b/aui.views/src/AUI/Platform/android/ACustomWindowImpl.cpp
@@ -19,8 +19,6 @@
 #include <cstring>
 #include <AUI/View/AButton.h>
 
-const int AUI_TITLE_HEIGHT = 30;
-
 
 void ACustomWindow::handleXConfigureNotify() {
 
@@ -40,7 +38,7 @@ void ACustomWindow::onPointerReleased(const APointerReleasedEvent& event) {
 
 
 bool ACustomWindow::isCaptionAt(const glm::ivec2& pos) {
-    if (pos.y <= AUI_TITLE_HEIGHT) {
+    if (pos.y <= mTitleHeight) {
         if (auto v = getViewAtRecursive(pos)) {
             if (!(_cast<AButton>(v)) &&
                 !v->getAssNames().contains(".override-title-dragging")) {

--- a/aui.views/src/AUI/Platform/ios/ACustomWindowImpl.cpp
+++ b/aui.views/src/AUI/Platform/ios/ACustomWindowImpl.cpp
@@ -19,8 +19,6 @@
 #include <cstring>
 #include <AUI/View/AButton.h>
 
-const int AUI_TITLE_HEIGHT = 30;
-
 #if AUI_PLATFORM_WIN
 #include <glm/gtc/matrix_transform.hpp>
 
@@ -214,7 +212,7 @@ ACustomWindow::ACustomWindow(const AString& name, int width, int height) :
     setWindowStyle(WindowStyle::NO_DECORATORS);
 }
 void ACustomWindow::onPointerPressed(const APointerPressedEvent& event) {
-    if (event.position.y < AUI_TITLE_HEIGHT) {
+    if (event.position.y < mTitleHeight) {
         if (isCaptionAt(event.position)) {
             // TODO apple
 
@@ -249,7 +247,7 @@ ACustomWindow::ACustomWindow(const AString& name, int width, int height) :
 }
 
 void ACustomWindow::onPointerPressed(glm::ivec2 pos, AInput::Key button) {
-    if (pos.y < AUI_TITLE_HEIGHT && button == AInput::LBUTTON) {
+    if (pos.y < mTitleHeight && button == AInput::LBUTTON) {
         if (isCaptionAt(pos)) {
             XClientMessageEvent xclient;
             memset(&xclient, 0, sizeof(XClientMessageEvent));
@@ -293,7 +291,7 @@ void ACustomWindow::handleXConfigureNotify() {
 
 
 bool ACustomWindow::isCaptionAt(const glm::ivec2& pos) {
-    if (pos.y <= AUI_TITLE_HEIGHT) {
+    if (pos.y <= mTitleHeight) {
         if (auto v = getViewAtRecursive(pos)) {
             if (!(_cast<AButton>(v)) &&
                 !v->getAssNames().contains(".override-title-dragging")) {

--- a/aui.views/src/AUI/Platform/linux/ACustomWindowImpl.cpp
+++ b/aui.views/src/AUI/Platform/linux/ACustomWindowImpl.cpp
@@ -20,8 +20,6 @@
 #include <cstring>
 #include <AUI/View/AButton.h>
 
-const int AUI_TITLE_HEIGHT = 30;
-
 ACustomWindow::ACustomWindow(const AString& name, int width, int height) :
         AWindow(name, width, height) {
 
@@ -30,7 +28,7 @@ ACustomWindow::ACustomWindow(const AString& name, int width, int height) :
 }
 
 void ACustomWindow::onPointerPressed(const APointerPressedEvent& event) {
-    if (event.position.y < AUI_TITLE_HEIGHT && event.asButton == AInput::LBUTTON) {
+    if (event.position.y < mTitleHeight && event.asButton == AInput::LBUTTON) {
         if (isCaptionAt(event.position)) {
             XClientMessageEvent xclient;
             memset(&xclient, 0, sizeof(XClientMessageEvent));
@@ -70,7 +68,7 @@ void ACustomWindow::handleXConfigureNotify() {
 
 
 bool ACustomWindow::isCaptionAt(const glm::ivec2& pos) {
-    if (pos.y <= AUI_TITLE_HEIGHT) {
+    if (pos.y <= mTitleHeight) {
         if (auto v = getViewAtRecursive(pos)) {
             if (!(_cast<AButton>(v)) &&
                 !v->getAssNames().contains(".override-title-dragging")) {

--- a/aui.views/src/AUI/Platform/linux/AMessageBoxImpl.cpp
+++ b/aui.views/src/AUI/Platform/linux/AMessageBoxImpl.cpp
@@ -44,6 +44,11 @@ namespace {
                                 Button { "Yes"_i18n }.clicked(me::onYes),
                                 Button { "No"_i18n }.clicked(me::onNo),
                             };
+                            case AMessageBox::Button::YES_NO_CANCEL: return Horizontal {
+                                Button { "Yes"_i18n }.clicked(me::onYes),
+                                Button { "No"_i18n }.clicked(me::onNo),
+                                Button { "Cancel"_i18n }.clicked(me::onCancel),
+                            };
                             default: throw AException("invalid AMessageBox::Button");
                         }
                     },

--- a/aui.views/src/AUI/Platform/macos/ACustomWindowImpl.cpp
+++ b/aui.views/src/AUI/Platform/macos/ACustomWindowImpl.cpp
@@ -19,8 +19,6 @@
 #include <cstring>
 #include <AUI/View/AButton.h>
 
-const int AUI_TITLE_HEIGHT = 30;
-
 #if AUI_PLATFORM_WIN
 #include <glm/gtc/matrix_transform.hpp>
 
@@ -241,7 +239,7 @@ ACustomWindow::ACustomWindow(const AString& name, int width, int height) :
 }
 
 void ACustomWindow::onPointerPressed(glm::ivec2 pos, AInput::Key button) {
-    if (pos.y < AUI_TITLE_HEIGHT && button == AInput::LBUTTON) {
+    if (pos.y < mTitleHeight && button == AInput::LBUTTON) {
         if (isCaptionAt(pos)) {
             XClientMessageEvent xclient;
             memset(&xclient, 0, sizeof(XClientMessageEvent));
@@ -285,7 +283,7 @@ void ACustomWindow::handleXConfigureNotify() {
 
 
 bool ACustomWindow::isCaptionAt(const glm::ivec2& pos) {
-    if (pos.y <= AUI_TITLE_HEIGHT) {
+    if (pos.y <= mTitleHeight) {
         if (auto v = getViewAtRecursive(pos)) {
             if (!(_cast<AButton>(v)) &&
                 !v->getAssNames().contains(".override-title-dragging")) {

--- a/aui.views/src/AUI/Platform/win32/ACustomWindowImpl.cpp
+++ b/aui.views/src/AUI/Platform/win32/ACustomWindowImpl.cpp
@@ -19,8 +19,6 @@
 #include <cstring>
 #include <AUI/View/AButton.h>
 
-const int AUI_TITLE_HEIGHT = 30;
-
 #if AUI_PLATFORM_WIN
 #include <glm/gtc/matrix_transform.hpp>
 
@@ -214,7 +212,7 @@ ACustomWindow::ACustomWindow(const AString& name, int width, int height) :
     setWindowStyle(WindowStyle::NO_DECORATORS);
 }
 void ACustomWindow::onPointerPressed(glm::ivec2 pos, AInput::Key button) {
-    if (pos.y < AUI_TITLE_HEIGHT && button == AInput::LBUTTON) {
+    if (pos.y < mTitleHeight && button == AInput::LBUTTON) {
         if (isCaptionAt(pos)) {
             // TODO apple
 
@@ -250,7 +248,7 @@ ACustomWindow::ACustomWindow(const AString& name, int width, int height) :
 }
 
 void ACustomWindow::onPointerPressed(glm::ivec2 pos, AInput::Key button) {
-    if (pos.y < AUI_TITLE_HEIGHT && button == AInput::LBUTTON) {
+    if (pos.y < mTitleHeight && button == AInput::LBUTTON) {
         if (isCaptionAt(pos)) {
             XClientMessageEvent xclient;
             memset(&xclient, 0, sizeof(XClientMessageEvent));
@@ -294,7 +292,7 @@ void ACustomWindow::handleXConfigureNotify() {
 
 
 bool ACustomWindow::isCaptionAt(const glm::ivec2& pos) {
-    if (pos.y <= AUI_TITLE_HEIGHT) {
+    if (pos.y <= mTitleHeight) {
         if (auto v = getViewAtRecursive(pos)) {
             if (!(_cast<AButton>(v)) &&
                 !v->getAssNames().contains(".override-title-dragging")) {

--- a/aui.views/src/AUI/Platform/win32/AMessageBoxImpl.cpp
+++ b/aui.views/src/AUI/Platform/win32/AMessageBoxImpl.cpp
@@ -53,6 +53,10 @@ AMessageBox::ResultButton AMessageBox::show(AWindow* parent, const AString& titl
         case Button::YES_NO:
             flags |= MB_YESNO;
             break;
+
+        case Button::YES_NO_CANCEL:
+            flags |= MB_YESNOCANCEL;
+            break;
     }
 
     switch (::MessageBox(window, message.c_str(), title.c_str(), flags)) {

--- a/aui.views/src/AUI/Util/ADataBinding.h
+++ b/aui.views/src/AUI/Util/ADataBinding.h
@@ -354,7 +354,7 @@ _<View> operator&&(const _<View>& object, const ADataBindingLinker2<Model, Data>
     using pointer_to_setter = decltype( my_pointer_to_member::with_args(std::declval<setter_args>()));
 
     object && (*linker.getBinder())(linker.getField(),
-                                    static_cast<ASignal<Data>(View::*)>(ADataBindingDefault<View, Data>::getGetter()),
+                                    (ASignal<Data>(View::*))(ADataBindingDefault<View, Data>::getGetter()),
                                     static_cast<pointer_to_setter>(ADataBindingDefault<View, Data>::getSetter()));
     return object;
 }

--- a/aui.views/src/AUI/View/ADoubleNumberPicker.h
+++ b/aui.views/src/AUI/View/ADoubleNumberPicker.h
@@ -103,6 +103,8 @@ namespace aui::impl {
     public:
 
         static void setup(const _<ADoubleNumberPicker>& view) {
+            view->setMin((std::numeric_limits<Num>::min)());
+            view->setMax((std::numeric_limits<Num>::max)());
         }
 
         static auto getGetter() {

--- a/aui.views/src/AUI/View/ADoubleNumberPicker.h
+++ b/aui.views/src/AUI/View/ADoubleNumberPicker.h
@@ -15,32 +15,31 @@
 // License along with this library. If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
+
+#include <AUI/Traits/values.h>
+#include <AUI/Util/ADataBinding.h>
+
+#include "AAbstractTextField.h"
 #include "AViewContainer.h"
-#include "ATextField.h"
-#include <limits>
 
 /**
  * @brief A text field for numbers with increase/decrease buttons.
  * @ingroup useful_views
  */
-class API_AUI_VIEWS ADoubleNumberPicker: public AViewContainer
-{
-private:
-    class ADoubleNumberPickerField: public AAbstractTextField
-    {
-    private:
+class API_AUI_VIEWS ADoubleNumberPicker : public AViewContainer {
+   private:
+    class ADoubleNumberPickerField : public AAbstractTextField {
+       private:
         ADoubleNumberPicker& mPicker;
-    public:
-        ADoubleNumberPickerField(::ADoubleNumberPicker& picker)
-                : mPicker(picker)
-        {
-        }
+
+       public:
+        ADoubleNumberPickerField(::ADoubleNumberPicker& picker) : mPicker(picker) {}
 
         virtual ~ADoubleNumberPickerField() = default;
 
         void onKeyRepeat(AInput::Key key) override;
 
-    protected:
+       protected:
         bool isValidText(const AString& text) override;
     };
 
@@ -49,34 +48,20 @@ private:
     double mMin = 0;
     double mMax = 100;
 
-public:
+   public:
     ADoubleNumberPicker();
 
     int getContentMinimumHeight(ALayoutDirection layout) override;
 
     void setValue(double v);
 
-    [[nodiscard]]
-    const AString& text() const noexcept {
-        return mTextField->text();
-    }
+    [[nodiscard]] const AString& text() const noexcept { return mTextField->text(); }
 
-    [[nodiscard]]
-    double getValue() const {
-        return mTextField->text().toDouble().valueOr(0.0);
-    }
+    [[nodiscard]] double getValue() const { return mTextField->text().toDouble().valueOr(0.0); }
 
+    [[nodiscard]] double getMin() const { return mMin; }
 
-    [[nodiscard]] double getMin() const
-    {
-        return mMin;
-    }
-
-    [[nodiscard]] double getMax() const
-    {
-        return mMax;
-    }
-
+    [[nodiscard]] double getMax() const { return mMax; }
 
     void setMin(double min);
     void setMax(double max);
@@ -85,7 +70,7 @@ public:
     void decrease();
     void changeBy(double v);
 
-signals:
+   signals:
     /**
      * @brief Number changed.
      */
@@ -98,24 +83,38 @@ signals:
 };
 
 namespace aui::impl {
-    template<typename Num>
-    struct ADataBindingDefaultDoubleNumberPicker {
-    public:
+template <typename Num>
+struct ADataBindingDefaultDoubleNumberPicker {
+   public:
+    static void setup(const _<ADoubleNumberPicker>& view) {}
 
-        static void setup(const _<ADoubleNumberPicker>& view) {
-            view->setMin((std::numeric_limits<Num>::min)());
-            view->setMax((std::numeric_limits<Num>::max)());
-        }
+    static auto getGetter() { return &ADoubleNumberPicker::valueChanged; }
 
-        static auto getGetter() {
-            return &ADoubleNumberPicker::valueChanged;
-        }
+    static auto getSetter() { return &ADoubleNumberPicker::setValue; }
+};
 
-        static auto getSetter() {
-            return &ADoubleNumberPicker::setValue;
-        }
-    };
-}
+template <aui::arithmetic UnderlyingType, auto min, auto max>
+    requires aui::convertible_to<decltype(min), UnderlyingType> && aui::convertible_to<decltype(max), UnderlyingType>
+struct ADataBindingRangedDoubleNumberPicker {
+   public:
+    static void setup(const _<ADoubleNumberPicker>& view) {
+        view->setMin(aui::ranged_number<UnderlyingType, min, max>::MIN);
+        view->setMax(aui::ranged_number<UnderlyingType, min, max>::MAX);
+    }
 
-template<> struct ADataBindingDefault<ADoubleNumberPicker, double>: aui::impl::ADataBindingDefaultDoubleNumberPicker<double> {};
-template<> struct ADataBindingDefault<ADoubleNumberPicker, float>: aui::impl::ADataBindingDefaultDoubleNumberPicker<float> {};
+    static auto getGetter() { return &ADoubleNumberPicker::valueChanged; }
+
+    static auto getSetter() { return &ADoubleNumberPicker::setValue; }
+};
+}   // namespace aui::impl
+
+template <>
+struct ADataBindingDefault<ADoubleNumberPicker, double> : aui::impl::ADataBindingDefaultDoubleNumberPicker<double> {};
+
+template <>
+struct ADataBindingDefault<ADoubleNumberPicker, float> : aui::impl::ADataBindingDefaultDoubleNumberPicker<float> {};
+
+template <aui::arithmetic UnderlyingType, auto min, auto max>
+    requires aui::convertible_to<decltype(min), UnderlyingType> && aui::convertible_to<decltype(max), UnderlyingType>
+struct ADataBindingDefault<ADoubleNumberPicker, aui::ranged_number<UnderlyingType, min, max>>
+    : aui::impl::ADataBindingRangedDoubleNumberPicker<UnderlyingType, min, max> {};

--- a/aui.views/src/AUI/View/AForEachUI.h
+++ b/aui.views/src/AUI/View/AForEachUI.h
@@ -76,4 +76,5 @@ public:
     }
 };
 
-#define AUI_DECLARATIVE_FOR(value, model, layout) _new<AForEachUI<std::decay_t<decltype(model)>::stored_t::stored_t, layout>>(model) - [&](const std::decay_t<decltype(model)>::stored_t::stored_t& value, unsigned index) -> _<AView>
+#define AUI_DECLARATIVE_FOR_EX(value, model, layout, ...) _new<AForEachUI<std::decay_t<decltype(model)>::stored_t::stored_t, layout>>(model) - [__VA_ARGS__](const std::decay_t<decltype(model)>::stored_t::stored_t& value, unsigned index) -> _<AView>
+#define AUI_DECLARATIVE_FOR(value, model, layout) AUI_DECLARATIVE_FOR_EX(value, model, layout, =)

--- a/aui.views/src/AUI/View/AListView.h
+++ b/aui.views/src/AUI/View/AListView.h
@@ -16,13 +16,12 @@
 
 #pragma once
 
+#include <AUI/Model/AListModelIndex.h>
 #include <AUI/Model/AListModelObserver.h>
 #include <AUI/Model/AListModelSelection.h>
+#include <AUI/Model/IListModel.h>
 
-#include "AScrollbar.h"
-#include "AUI/Model/AListModelIndex.h"
-#include "AUI/Model/IListModel.h"
-#include "AUI/View/AScrollArea.h"
+#include "AScrollArea.h"
 
 class AListItem;
 class AListViewContainer;
@@ -46,13 +45,43 @@ class API_AUI_VIEWS AListView : public AScrollArea, public AListModelObserver<AS
     void clearSelectionInternal();
 
    public:
+    /**
+     * @brief Selection action for updateSelectionOnItem.
+     */
+    enum class SelectAction {
+        /**
+         * @brief Clears old selection and selects the specified index. Used by selectItem.
+         */
+        CLEAR_SELECTION_AND_SET,
+
+        /**
+         * @brief Selects the specified index. In single selection mode, acts like CLEAR_SELECTION_AND_SET.
+         */
+        SET,
+
+        /**
+         * @brief Deselects the specified index.
+         */
+        UNSET,
+
+        /**
+         * @brief Selects or deselects the specified index depending on it's current state.
+         */
+        TOGGLE,
+    };
+
     AListView() : AListView(nullptr) {}
     explicit AListView(const _<IListModel<AString>>& model);
     virtual ~AListView();
 
     void setModel(const _<IListModel<AString>>& model);
 
-    void selectItem(size_t i);
+    void updateSelectionOnItem(size_t i, AListView::SelectAction action);
+
+    /**
+     * @brief Acts on the item at index i as if the user were left-clicked without keyboard modifiers on it.
+     */
+    void selectItem(size_t i) { updateSelectionOnItem(i, SelectAction::CLEAR_SELECTION_AND_SET); }
 
     int getContentFullHeight() { return getLayout()->getMinimumHeight() + 8; }
 

--- a/aui.views/src/AUI/View/AListView.h
+++ b/aui.views/src/AUI/View/AListView.h
@@ -16,12 +16,13 @@
 
 #pragma once
 
-#include <AUI/Model/AListModelSelection.h>
 #include <AUI/Model/AListModelObserver.h>
-#include "AUI/View/AScrollArea.h"
+#include <AUI/Model/AListModelSelection.h>
+
+#include "AScrollbar.h"
 #include "AUI/Model/AListModelIndex.h"
 #include "AUI/Model/IListModel.h"
-#include "AScrollbar.h"
+#include "AUI/View/AScrollArea.h"
 
 class AListItem;
 class AListViewContainer;
@@ -30,36 +31,36 @@ class AListViewContainer;
  * @brief Displays a list model of strings.
  * @ingroup useful_views
  */
-class API_AUI_VIEWS AListView: public AScrollArea, public AListModelObserver<AString>::IListModelListener
-{
+class API_AUI_VIEWS AListView : public AScrollArea, public AListModelObserver<AString>::IListModelListener {
     friend class AListItem;
-private:
+
+   private:
     _<AListViewContainer> mContent;
-	ASet<AListModelIndex> mSelectionModel;
-	_<AListModelObserver<AString>> mObserver;
+    ASet<AListModelIndex> mSelectionModel;
+    _<AListModelObserver<AString>> mObserver;
     bool mAllowMultipleSelection = false;
 
     void handleMousePressed(AListItem* item);
     void handleMouseDoubleClicked(AListItem* item);
-	
-public:
-    AListView(): AListView(nullptr) {}
-	explicit AListView(const _<IListModel<AString>>& model);
+
+    void clearSelectionInternal();
+
+   public:
+    AListView() : AListView(nullptr) {}
+    explicit AListView(const _<IListModel<AString>>& model);
     virtual ~AListView();
 
     void setModel(const _<IListModel<AString>>& model);
 
     void selectItem(size_t i);
 
-    int getContentFullHeight() {
-        return getLayout()->getMinimumHeight() + 8;
-    }
+    int getContentFullHeight() { return getLayout()->getMinimumHeight() + 8; }
 
     void setAllowMultipleSelection(bool allowMultipleSelection);
 
     [[nodiscard]] AListModelSelection<AString> getSelectionModel() const {
-	    return AListModelSelection<AString>(mSelectionModel, mObserver->getModel());
-	}
+        return AListModelSelection<AString>(mSelectionModel, mObserver->getModel());
+    }
 
     void insertItem(size_t at, const AString& value) override;
     void updateItem(size_t at, const AString& value) override;
@@ -68,11 +69,11 @@ public:
     void onDataCountChanged() override;
     void onDataChanged() override;
 
-signals:
-	emits<AListModelSelection<AString>> selectionChanged;
-	emits<unsigned> itemDoubleClicked;
+   signals:
+    emits<AListModelSelection<AString>> selectionChanged;
+    emits<unsigned> itemDoubleClicked;
 
     void clearSelection();
 
-    bool onGesture(const glm::ivec2 &origin, const AGestureEvent &event) override;
+    bool onGesture(const glm::ivec2& origin, const AGestureEvent& event) override;
 };

--- a/aui.views/src/AUI/View/ANumberPicker.h
+++ b/aui.views/src/AUI/View/ANumberPicker.h
@@ -15,32 +15,31 @@
 // License along with this library. If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
+
+#include <AUI/Traits/values.h>
+#include <AUI/Util/ADataBinding.h>
+
+#include "AAbstractTextField.h"
 #include "AViewContainer.h"
-#include "ATextField.h"
-#include <limits>
 
 /**
  * @brief A text field for numbers with increase/decrease buttons.
  * @ingroup useful_views
  */
-class API_AUI_VIEWS ANumberPicker: public AViewContainer
-{
-private:
-    class ANumberPickerField: public AAbstractTextField
-    {
-    private:
+class API_AUI_VIEWS ANumberPicker : public AViewContainer {
+   private:
+    class ANumberPickerField : public AAbstractTextField {
+       private:
         ANumberPicker& mPicker;
-    public:
-        ANumberPickerField(::ANumberPicker& picker)
-                : mPicker(picker)
-        {
-        }
+
+       public:
+        ANumberPickerField(::ANumberPicker& picker) : mPicker(picker) {}
 
         virtual ~ANumberPickerField() = default;
 
         void onKeyRepeat(AInput::Key key) override;
 
-    protected:
+       protected:
         bool isValidText(const AString& text) override;
     };
 
@@ -49,7 +48,7 @@ private:
     int64_t mMin = 0;
     int64_t mMax = 100;
 
-public:
+   public:
     ANumberPicker();
 
     int getContentMinimumHeight(ALayoutDirection layout) override;
@@ -57,31 +56,20 @@ public:
     void setValue(int64_t v);
     int64_t getValue() const;
 
-    [[nodiscard]]
-    const AString& text() const noexcept {
-        return mTextField->text();
-    }
+    [[nodiscard]] const AString& text() const noexcept { return mTextField->text(); }
 
     void increase();
     void decrease();
     void changeBy(int64_t v);
 
+    [[nodiscard]] int64_t getMin() const { return mMin; }
 
-    [[nodiscard]] int64_t getMin() const
-    {
-        return mMin;
-    }
-
-    [[nodiscard]] int64_t getMax() const
-    {
-        return mMax;
-    }
-
+    [[nodiscard]] int64_t getMax() const { return mMax; }
 
     void setMin(int64_t min);
     void setMax(int64_t max);
 
-signals:
+   signals:
     /**
      * @brief Number changed.
      */
@@ -94,29 +82,53 @@ signals:
 };
 
 namespace aui::impl {
-    template<typename Num>
-    struct ADataBindingDefaultNumberPicker {
-    public:
+template <typename Num>
+struct ADataBindingDefaultNumberPicker {
+   public:
+    static void setup(const _<ANumberPicker>& view) {}
 
-        static void setup(const _<ANumberPicker>& view) {
-            view->setMin((std::numeric_limits<Num>::min)());
-            view->setMax((std::numeric_limits<Num>::max)());
-        }
+    static auto getGetter() { return &ANumberPicker::valueChanged; }
 
-        static auto getGetter() {
-            return &ANumberPicker::valueChanged;
-        }
+    static auto getSetter() { return &ANumberPicker::setValue; }
+};
 
-        static auto getSetter() {
-            return &ANumberPicker::setValue;
-        }
-    };
-}
+template <aui::arithmetic UnderlyingType, auto min, auto max>
+    requires aui::convertible_to<decltype(min), UnderlyingType> && aui::convertible_to<decltype(max), UnderlyingType>
+struct ADataBindingRangedNumberPicker {
+   public:
+    static void setup(const _<ANumberPicker>& view) {
+        view->setMin(aui::ranged_number<UnderlyingType, min, max>::MIN);
+        view->setMax(aui::ranged_number<UnderlyingType, min, max>::MAX);
+    }
 
-template<> struct ADataBindingDefault<ANumberPicker, uint8_t>: aui::impl::ADataBindingDefaultNumberPicker<uint8_t> {};
-template<> struct ADataBindingDefault<ANumberPicker, int8_t>: aui::impl::ADataBindingDefaultNumberPicker<int8_t> {};
-template<> struct ADataBindingDefault<ANumberPicker, uint16_t>: aui::impl::ADataBindingDefaultNumberPicker<uint16_t> {};
-template<> struct ADataBindingDefault<ANumberPicker, int16_t>: aui::impl::ADataBindingDefaultNumberPicker<int16_t> {};
-template<> struct ADataBindingDefault<ANumberPicker, uint32_t>: aui::impl::ADataBindingDefaultNumberPicker<uint32_t> {};
-template<> struct ADataBindingDefault<ANumberPicker, int32_t>: aui::impl::ADataBindingDefaultNumberPicker<int32_t> {};
-template<> struct ADataBindingDefault<ANumberPicker, int64_t>: aui::impl::ADataBindingDefaultNumberPicker<int64_t> {};
+    static auto getGetter() { return &ANumberPicker::valueChanged; }
+
+    static auto getSetter() { return &ANumberPicker::setValue; }
+};
+}   // namespace aui::impl
+
+template <>
+struct ADataBindingDefault<ANumberPicker, uint8_t> : aui::impl::ADataBindingDefaultNumberPicker<uint8_t> {};
+
+template <>
+struct ADataBindingDefault<ANumberPicker, int8_t> : aui::impl::ADataBindingDefaultNumberPicker<int8_t> {};
+
+template <>
+struct ADataBindingDefault<ANumberPicker, uint16_t> : aui::impl::ADataBindingDefaultNumberPicker<uint16_t> {};
+
+template <>
+struct ADataBindingDefault<ANumberPicker, int16_t> : aui::impl::ADataBindingDefaultNumberPicker<int16_t> {};
+
+template <>
+struct ADataBindingDefault<ANumberPicker, uint32_t> : aui::impl::ADataBindingDefaultNumberPicker<uint32_t> {};
+
+template <>
+struct ADataBindingDefault<ANumberPicker, int32_t> : aui::impl::ADataBindingDefaultNumberPicker<int32_t> {};
+
+template <>
+struct ADataBindingDefault<ANumberPicker, int64_t> : aui::impl::ADataBindingDefaultNumberPicker<int64_t> {};
+
+template <aui::arithmetic UnderlyingType, auto min, auto max>
+    requires aui::convertible_to<decltype(min), UnderlyingType> && aui::convertible_to<decltype(max), UnderlyingType>
+struct ADataBindingDefault<ANumberPicker, aui::ranged_number<UnderlyingType, min, max>>
+    : aui::impl::ADataBindingRangedNumberPicker<UnderlyingType, min, max> {};


### PR DESCRIPTION
Hey @Alex2772,

After a little cooldown period I'm back to work. There are the few updates I did so far while working on my app:

## Multiple selection on list view

The `AListView` supports multiple selection on click but not programmatically. I've updated the `selectItem(size_t)` method to add items in the current selection only if `mAllowMultipleSelection` is `true`.

## Do not override existing object when deserializing JSON

Actually when you deserialize a JSON object, the object you give as reference is overridden. This I think disallow some uses cases where I just want to fill missing fields from JSON data, or deserialize multiple JSON data in the same object for some process:

```cpp
SomeSerializableStruct obj;
// Fill some obj fields with custom data
AJsonConv<SomeSerializableStruct>::fromJSON(json1, obj); // Fill some other obj fields with JSON data, we want to keep the previous state
// Do some processing, update obj state
AJsonConv<SomeSerializableStruct>::fromJSON(json2, obj); // Update some fields with another JSON data, we want to keep the previous state again
// Do some other stuff with obj
```

For that I just used the `aui::from_json<T>()` overload that takes the object in which deserialize data as a reference.

## Allow to set the height for custom window's title

The height was fixed to 30, but for some specific UI it needed to be updated... I've added the ability to do that by keeping the default value of 30.

## Added YES_NO_CANCEL mode for message boxes

Windows supports it natively, I've added the necessary changes for Linux, MacOS platforms are not yet supported.

## Improved menu display in `AWindowMenuProvider`

The display of menu using the `AWindowMenuProvider` had several issues for me:

- `SUBLIST` items were displayed on top of parents;
- Once a `SUBLIST` item is displayed, only his parent is destroyed on menu destroy, sublist are still shown;
- `SUBLIST` items were displayed too early (as soon as the cursor is on top of the parent item) which is not good UX I think;
- The styling of items with shortcuts and items without shortcuts was difficult to normalize due to the different UI hierarchy.

## Allow to set custom capture context for `AUI_DECLARATIVE_FOR`

I've added the `AUI_DECLARATIVE_FOR_EX` macro which allows to set a custom capture context for the lambda function. Also updated `AUI_DECLARATIVE_FOR` to use `=` as the default capture context instead of `&` (the latter was causing some reference issues, since it captures everything by address).

Waiting for your feedback!