### PR TITLE
Feat/future spinlock

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -63,6 +63,36 @@
             ],
             "preLaunchTask": "CMake: build Tests"
         },
+        {
+            "name": "Benchmarks",
+            "type": "cppdbg",
+            "request": "launch",
+            "program": "${workspaceRoot}/build/bin/Benchmarks",
+            //"args": ["--gtest_filter=\"Strings*\""],
+            "stopAtEntry": false,
+            "cwd": "${workspaceRoot}/build/bin/",
+            "environment": [],
+            "externalConsole": false,
+            "MIMode": "gdb",
+            "setupCommands": [
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "python import sys;sys.path.insert(0, '/usr/share/gcc-13/python');from libstdcxx.v6.printers import register_libstdcxx_printers;register_libstdcxx_printers(None)",
+                    "ignoreFailures": false
+                },
+                {
+                    "description": "Enable pretty-printing for gdb",
+                    "text": "-enable-pretty-printing",
+                    "ignoreFailures": true
+                },
+                {
+                    "description": "Set Disassembly Flavor to Intel",
+                    "text": "-gdb-set disassembly-flavor intel",
+                    "ignoreFailures": true
+                }
+            ],
+            "preLaunchTask": "CMake: build Benchmarks"
+        },
 
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -29,5 +29,19 @@
 			"problemMatcher": [],
 			"detail": "CMake template build task"
 		},
+		{
+			"type": "cmake",
+			"label": "CMake: build Benchmarks",
+			"command": "build",
+			"targets": [
+				"Benchmarks"
+			],
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			},
+			"problemMatcher": [],
+			"detail": "CMake template build task"
+		},
 	]
 }

--- a/aui.core/benchmarks/FutureBenchmark.cpp
+++ b/aui.core/benchmarks/FutureBenchmark.cpp
@@ -1,0 +1,41 @@
+#include <benchmark/benchmark.h>
+#include "AUI/Thread/AFuture.h"
+#include "AUI/Thread/AThreadPool.h"
+#include "AUI/Util/Assert.h"
+
+
+static constexpr auto VALUE = 228;
+
+static void FutureImmediateValue(benchmark::State& state) {
+    for (auto _ : state) {
+        AFuture f(VALUE);
+        auto value = *f;
+        AUI_ASSERT(value == VALUE);
+        benchmark::DoNotOptimize(value);
+    }
+}
+BENCHMARK(FutureImmediateValue);
+
+static void FutureSingleThread(benchmark::State& state) {
+    for (auto _ : state) {
+        AFuture<int> f;
+        f.supplyValue(VALUE);
+        auto value = *f;
+        AUI_ASSERT(value == VALUE);
+        benchmark::DoNotOptimize(value);
+    }
+}
+BENCHMARK(FutureSingleThread);
+
+static void FutureMultiThread(benchmark::State& state) {
+    AThreadPool tp(1);
+    for (auto _ : state) {
+        AFuture<int> f = tp * [] {
+            return VALUE;  
+        };
+        auto value = *f;
+        AUI_ASSERT(value == VALUE);
+        benchmark::DoNotOptimize(value);
+    }
+}
+BENCHMARK(FutureMultiThread);

--- a/aui.core/src/AUI/Thread/AFuture.h
+++ b/aui.core/src/AUI/Thread/AFuture.h
@@ -130,7 +130,11 @@ namespace aui::impl::future {
              */
             std::conditional_t<isVoid, bool, AOptional<Value>> value;
             AOptional<AInvocationTargetException> exception;
-            AMutex mutex;
+            /**
+             * Spinlock mutex is used here because AFuture makes frequent calls to mutex and never locks for a long
+             * time. Durations are small enough so it is worth to just busy wait instead of making syscalls.
+             */
+            ASpinlockMutex mutex;
             AConditionVariable cv;
             TaskCallback task;
             OnSuccessCallback onSuccess;

--- a/aui.core/src/AUI/Thread/AMutex.h
+++ b/aui.core/src/AUI/Thread/AMutex.h
@@ -15,6 +15,7 @@
 // License along with this library. If not, see <http://www.gnu.org/licenses/>.
 
 #pragma once
+#include <atomic>
 #include <mutex>
 #include <shared_mutex>
 #include <thread>
@@ -32,12 +33,66 @@ namespace aui::detail {
     };
 }
 
+/**
+ * @brief Basic syscall-based synchronization primitive.
+ * @ingroup core
+ */
 struct AMutex: aui::detail::MutexExtras<std::mutex>{};
+
+/**
+ * @brief Like AMutex but can handle multiple locks for one thread (recursive).
+ * @ingroup core
+ * @details
+ * @note Please note that the usage of recursive mutex may indicate that your code may have architectural issues related
+ * to the concurrency (e.g., comodification of a container that is being foreach-looped). Use recursive mutex with care.
+ */
 struct ARecursiveMutex: aui::detail::MutexExtras<std::recursive_mutex>{};
+
+/**
+ * @brief Like AMutex but has shared lock type (in addition to basic lock which is unique locking) implementing RW
+ * synchronization.
+ * @ingroup core
+ */
 struct ASharedMutex: aui::detail::MutexExtras<std::shared_mutex> {
 public:
     void lock_shared() {
         APerformanceSection section("Mutex", AColor::RED);
         MutexExtras::lock_shared();
     }
+};
+
+
+/**
+ * @brief Synchronization primitive that is implemented with atomic values instead of doing syscalls.
+ * @details
+ * In contrast to a regular mutex, threads will busy-wait (infinitely check for unlocked state) and waste CPU cycles
+ * instead of yielding the CPU to another thread with a syscall.
+ *
+ * ASpinlockMutex may be faster than a regular mutex in some cases. Use benchmarks to compare. 
+ */
+class ASpinlockMutex {
+public:
+    void lock() {
+        APerformanceSection section("Mutex", AColor::RED);
+        while (!try_lock()) {
+            // busy-wait
+        }
+    }
+
+    /**
+     * @brief Tries to acquire the mutex without blocking.
+     * @return true if the mutex is successfully acquired, false otherwise.
+     */
+    [[nodiscard]]
+    bool try_lock() noexcept {
+        return mState.exchange(LOCKED, std::memory_order_acquire) == UNLOCKED;
+    }
+
+    void unlock() noexcept {
+        mState.store(UNLOCKED, std::memory_order_release);
+    }
+
+private:
+    enum State { UNLOCKED, LOCKED };
+    std::atomic<State> mState = UNLOCKED;
 };


### PR DESCRIPTION
```
Comparing ./Benchmarks.develop to ./Benchmarks
Benchmark                                 Time             CPU      Time Old      Time New       CPU Old       CPU New
----------------------------------------------------------------------------------------------------------------------
FutureImmediateValue                   +0.0162         +0.0162          1319          1340          1316          1337
FutureSingleThread                     +0.0193         +0.0191          1687          1720          1684          1716
FutureMultiThread1                     -0.2269         -0.2224          4530          3502          4483          3486
FutureMultiThread2                     +0.0006         +0.0408     105842632     105904555        634390        660286
StringUTF8                             +0.0088         +0.0102           246           248           245           247
JsonParse/iterations:10                -0.0101         -0.0101    2754266062    2726417137    2746855484    2719077705
OVERALL_GEOMEAN                        -0.0365         -0.0290             0             0             0             0
```