### PR TITLE
Custom AUI.Boot cache directory and new JSON converter

### DIFF
--- a/aui.boot.cmake
+++ b/aui.boot.cmake
@@ -116,8 +116,13 @@ else()
     set(AUI_TARGET_ABI "${_tmp}" CACHE INTERNAL "COMPILER-PROCESSOR pair")
 endif()
 
+# checking if custom cache dir is set for the system
+if(DEFINED ENV{AUIB_CACHE_DIR})
+    string(REPLACE "\\" "/" _tmp $ENV{AUIB_CACHE_DIR}) # little hack to handle Windows paths
+else()
+    set(_tmp ${HOME_DIR}/.aui)
+endif()
 
-set(_tmp ${HOME_DIR}/.aui)
 if(AUIB_LOCAL_CACHE)
     set(_tmp ${CMAKE_BINARY_DIR}/aui.boot)
 endif()

--- a/aui.json/src/AUI/Json/Conversion.h
+++ b/aui.json/src/AUI/Json/Conversion.h
@@ -273,6 +273,21 @@ struct AJsonConv<double> {
     }
 };
 
+template<aui::arithmetic UnderlyingType, auto min, auto max>
+    requires aui::convertible_to<decltype(min), UnderlyingType> && aui::convertible_to<decltype(max), UnderlyingType>
+struct AJsonConv<aui::ranged_number<UnderlyingType, min, max>> {
+    static AJson toJson(aui::ranged_number<UnderlyingType, min, max> v) {
+        return (UnderlyingType) v;
+    }
+    static void fromJson(const AJson& json, aui::ranged_number<UnderlyingType, min, max>& dst) {
+        if constexpr (aui::same_as<UnderlyingType, float> || aui::same_as<UnderlyingType, double>) {
+            dst = (UnderlyingType) json.asNumber();
+        } else {
+            dst = (UnderlyingType) json.asLongInt();
+        }
+    }
+};
+
 template<>
 struct AJsonConv<bool> {
     static AJson toJson(bool v) {


### PR DESCRIPTION
Hey @Alex2772, I added some little stuff in this PR.

## Custom AUI.Boot cache directory

I came up with a case where storing cached AUI.Boot dependencies in the HOME directory was not good due to storage space, and storing same dependencies per projects was not the solution too. So, I modified the CMake script to allow users to set an env variable `AUIB_CACHE_DIR` to the path they want as the AUI.Boot cache directory. If not set the behaviour is exactly the same as before. If set that path is used instead of the HOME directory. The `AUIB_LOCAL_CACHE` flag still force AUI.Boot to install deps locally even if the env var is set.

## JSON serialization of `aui::ranged_number`

My project uses ranged numbers for type safety, but for a JSON standpoint they are just numbers, so I've added a custom converter that converts ranged numbers from/to JSON values