### PR TITLE
Fixes and little updates

### DIFF
--- a/aui.core/src/AUI/Common/AColor.h
+++ b/aui.core/src/AUI/Common/AColor.h
@@ -26,22 +26,22 @@ class AString;
 class AColor: public glm::vec4
 {
 public:
-	AColor(): glm::vec4(0, 0, 0, 1.f)
+	constexpr AColor(): glm::vec4(0, 0, 0, 1.f)
 	{
 	}
-	AColor(const glm::vec4& v): glm::vec4(v){}
+	constexpr AColor(const glm::vec4& v): glm::vec4(v){}
 
     API_AUI_CORE AColor(const AString& s);
-	AColor(float scalar) : glm::vec4(scalar) {}
-	AColor(float r, float g, float b) : glm::vec4(r, g, b, 1.f) {}
-	AColor(float r, float g, float b, float a) : glm::vec4(r, g, b, a) {}
+	constexpr AColor(float scalar) : glm::vec4(scalar) {}
+	constexpr AColor(float r, float g, float b) : glm::vec4(r, g, b, 1.f) {}
+	constexpr AColor(float r, float g, float b, float a) : glm::vec4(r, g, b, a) {}
 
 	/**
 	 * @brief Construct with hex integer
 	 * @param color integer representing color in 0xRRGGBBAA
 	 * \example AColor(0xff0000ff) will represent opaque bright red
 	 */
-	AColor(unsigned int color) : glm::vec4(
+	constexpr AColor(unsigned int color) : glm::vec4(
 		((color >> 24) & 0xff) / 255.f, 
 		((color >> 16) & 0xff) / 255.f, 
 		((color >> 8) & 0xff) / 255.f, 
@@ -52,7 +52,7 @@ public:
      * @param color integer representing color in 0xAARRGGBB
      * \example AColor(0xff0000ff) will represent opaque bright blue
      */
-	static AColor fromAARRGGBB(unsigned int color)
+	static constexpr AColor fromAARRGGBB(unsigned int color)
 	{
 		return {
 		((color >> 16) & 0xff) / 255.f,
@@ -67,7 +67,7 @@ public:
      * @param color integer representing color in 0xRRGGBB
      * \example AColor(0x00ff00) will represent opaque bright green
      */
-	static AColor fromRRGGBB(unsigned int color)
+	static constexpr AColor fromRRGGBB(unsigned int color)
 	{
 		return {
 		((color >> 16) & 0xff) / 255.f,
@@ -77,7 +77,7 @@ public:
 		};
 	}
 	
-	AColor operator*(float other) const
+	constexpr AColor operator*(float other) const
 	{
 		return AColor(x * other, y * other, z * other, w * other);
 	}
@@ -112,13 +112,13 @@ public:
      * @param multiplier
      * @return supplyValue color
      */
-    inline AColor mul(float d) const {
+    inline constexpr AColor mul(float d) const {
         return glm::clamp(glm::vec4(r * d, g * d, b * d, a), glm::vec4(0.f), glm::vec4(1.f));
     }
-    inline AColor darker(float d) const {
+    inline constexpr AColor darker(float d) const {
         return mul(1.f - d);
     }
-    inline AColor lighter(float d) const {
+    inline constexpr AColor lighter(float d) const {
         return mul(1.f + d);
     }
 
@@ -170,7 +170,7 @@ inline std::ostream& operator<<(std::ostream& o, const AColor& color) {
  * @param color integer representing color in 0xAARRGGBB
  * \example AColor(0xff0000ff) will represent opaque bright blue
  */
-inline AColor operator"" _argb(unsigned long long v)
+inline constexpr AColor operator"" _argb(unsigned long long v)
 {
     return AColor::fromAARRGGBB(unsigned(v));
 }
@@ -181,7 +181,7 @@ inline AColor operator"" _argb(unsigned long long v)
  * @param color integer representing color in 0xRRGGBB
  * \example AColor(0x00ff00) will represent opaque bright green
  */
-inline AColor operator"" _rgb(unsigned long long v)
+inline constexpr AColor operator"" _rgb(unsigned long long v)
 {
 	assert(("_rgb literal should be in 0xrrggbb format, not 0xaarrggbb" && !(v & 0xff000000u)));
     return AColor::fromRRGGBB(unsigned(v));

--- a/aui.core/src/AUI/Geometry2D/ARect.h
+++ b/aui.core/src/AUI/Geometry2D/ARect.h
@@ -29,7 +29,7 @@ struct ARect {
     }
 
     static ARect fromCenterPositionAndSize(APoint2D<T> position, APoint2D<T> size) {
-        return { .p1 = position - size / 2, .p2 = position + size / 2 };
+        return { .p1 = position - size / static_cast<T>(2), .p2 = position + size / static_cast<T>(2) };
     }
 
     bool operator==(const ARect&) const noexcept = default;
@@ -56,7 +56,7 @@ struct ARect {
 
     [[nodiscard]]
     APoint2D<T> center() const noexcept {
-        return (p1 + p2) / 2;
+        return (p1 + p2) / static_cast<T>(2);
     }
 
     [[nodiscard]]

--- a/aui.core/src/AUI/IO/APath.cpp
+++ b/aui.core/src/AUI/IO/APath.cpp
@@ -207,6 +207,7 @@ APath APath::absolute() const {
         aui::impl::lastErrorToException("could not find absolute file \"" + *this + "\"");
     }
     buf.resizeToNullTerminator();
+    buf.removeBackSlashes();
     return buf;
 #else
     auto rawPath = aui::ptr::make_unique_with_deleter(realpath(toStdString().c_str(), nullptr), free);
@@ -318,7 +319,7 @@ APath APath::workingDir() {
     APath p;
     p.resize(0x800);
     p.resize(GetCurrentDirectory(p.length(), aui::win32::toWchar(p)));
-    p.replaceAll('\\', '/');
+    p.removeBackSlashes();
     return p;
 }
 

--- a/aui.views/src/AUI/Util/UIBuildingHelpers.h
+++ b/aui.views/src/AUI/Util/UIBuildingHelpers.h
@@ -106,6 +106,17 @@ using Horizontal = aui::ui_building::layouted_container_factory<AHorizontalLayou
 using Stacked = aui::ui_building::layouted_container_factory<AStackedLayout>;
 
 /**
+ * Places views according to specified xy coordinates.
+ * <p>
+ *  <dl>
+ *    <dt><b>View:</b> AViewContainer</dt>
+ *    <dt><b>Layout manager:</b> AAbsoluteLayout</dt>
+ *  </dl>
+ * </p>
+ */
+using Absolute = aui::ui_building::layouted_container_factory<AAbsoluteLayout>;
+
+/**
  * Does not actually set the layout. The views' geometry is determined manually.
  * @deprecated Use AAbsoluteLayout instead.
  * <p>


### PR DESCRIPTION
Hey @Alex2772 

These are the recent fixes and changes I made while working with AUI.

## Enabled `constexpr` in `AColor`

Since `AColor` ihnerits from `glm::vec4` and most of `glm` methods/operators are `constexpr`, I've enabled `constexpr` in AColor too, where applicable.

## Fixed compile issues with `ARect<float>`

The issue was because `glm` is strict with vector and scalar operations, they need to have the same type. So, a `glm::vec<2, float>` has only operator with `float` scalars. I had to cast the scalars in `ARect<T>` to `T` so the compiler will always find the correct operator.

## Fixed assert in `APath::relativeTo()` on Windows platforms

I had issues with `APath::relativeTo()` that was always throwing an assert (`AUI_ASSERT(startsWith(f))`) on Windows. It ended that the issue was because the `APath::absolute()` method was not normalizing the path separator, and kept the `\` from Windows. Changing `\` to `/` after getting the absolute path fixed the issue.

## Added `Absolute` layout helper

I've added a helper for `AAbsoluteLayout`, following previous declarations.