### PR TITLE
data binding improvements

### DIFF
--- a/aui.core/src/AUI/Common/SharedPtrTypes.h
+++ b/aui.core/src/AUI/Common/SharedPtrTypes.h
@@ -309,6 +309,11 @@ public:
         return *this;
     }
 
+    template<typename... Arg>
+    auto operator()(Arg&&... value) const requires std::is_invocable_v<T, Arg...> {
+        return (*super::get())(std::forward<Arg>(value)...);
+    }
+
     template<typename Arg>
     const _<T>& operator+(Arg&& value) const {
         (*super::get()) + std::forward<Arg>(value);

--- a/aui.core/src/AUI/Model/AListModel.h
+++ b/aui.core/src/AUI/Model/AListModel.h
@@ -246,6 +246,20 @@ public:
         return list;
     }
 
+    /**
+     * Create AListModel from initializer list. Applicable for initializing AListModel<AString> from
+     * const char* initializer list.
+     *
+     * @tparam V type that converts to T
+     * @return a new AListModel
+     */
+    template<typename V>
+    static _<AListModel<StoredType>> fromVector(std::vector<V> t) {
+        auto list = _new<AListModel<StoredType>>();
+        list->mVector = AVector<StoredType>(std::vector<StoredType>(std::move(t)));
+        return list;
+    }
+
     template<typename UnaryOperation>
     auto map(UnaryOperation&& transformer) {
         return mVector.map(std::forward<UnaryOperation>(transformer));

--- a/aui.views/src/AUI/Util/ADataBinding.h
+++ b/aui.views/src/AUI/Util/ADataBinding.h
@@ -338,6 +338,7 @@ template<typename View, typename Model, typename Data>
 _<View> operator&&(const _<View>& object, const ADataBindingLinker2<Model, Data>& linker) {
     ADataBindingDefault<View, Data>::setup(object);
 
+    using getter = ASignal<Data>(View::*);
     using setter = aui::member<decltype(ADataBindingDefault<View, Data>::getSetter())>;
 
     using setter_ret = typename setter::return_t;
@@ -347,8 +348,14 @@ _<View> operator&&(const _<View>& object, const ADataBindingLinker2<Model, Data>
 
     using pointer_to_setter = decltype( my_pointer_to_member::with_args(std::declval<setter_args>()));
 
+    getter g = nullptr;
+    // getter is optional.
+    if constexpr (requires {  ADataBindingDefault<View, Data>::getGetter(); }) {
+        g = (getter) (ADataBindingDefault<View, Data>::getGetter());
+    }
+
     object && (*linker.getBinder())(linker.getField(),
-                                    (ASignal<Data>(View::*))(ADataBindingDefault<View, Data>::getGetter()),
+                                    g,
                                     static_cast<pointer_to_setter>(ADataBindingDefault<View, Data>::getSetter()));
     return object;
 }

--- a/aui.views/src/AUI/View/ADrawableView.cpp
+++ b/aui.views/src/AUI/View/ADrawableView.cpp
@@ -25,15 +25,20 @@ ADrawableView::ADrawableView(const _<IDrawable>& drawable) : mDrawable(drawable)
 
 void ADrawableView::render(ARenderContext context) {
     AView::render(context);
-    context.render.setColor(getAssHelper()->state.backgroundUrl.overlayColor.orDefault(0xffffff_rgb));
-    if (mDrawable) {
-        IDrawable::Params p;
-        p.size = getSize();
-        mDrawable->draw(context.render, p);
+    if (!mDrawable) {
+        return;
     }
+    context.render.setColor(getAssHelper()->state.backgroundUrl.overlayColor.orDefault(0xffffff_rgb));
+    IDrawable::Params p;
+    p.size = getSize();
+    mDrawable->draw(context.render, p);
 }
 
 ADrawableView::ADrawableView(const AUrl& url): ADrawableView(IDrawable::fromUrl(url)) {
+
+}
+
+ADrawableView::ADrawableView() {
 
 }
 

--- a/aui.views/src/AUI/View/ADrawableView.h
+++ b/aui.views/src/AUI/View/ADrawableView.h
@@ -27,6 +27,7 @@ class API_AUI_VIEWS ADrawableView: public AView {
 public:
     explicit ADrawableView(const AUrl& url);
     explicit ADrawableView(const _<IDrawable>& drawable);
+    ADrawableView();
     void render(ARenderContext context) override;
 
     void setDrawable(const _<IDrawable>& drawable) {
@@ -43,6 +44,14 @@ private:
     _<IDrawable> mDrawable;
 };
 
+template<>
+struct ADataBindingDefault<ADrawableView, _<IDrawable>> {
+public:
+    static void setup(const _<ADrawableView>& view) {
+    }
+
+    static auto getSetter() { return &ADrawableView::setDrawable; }
+};
 
 namespace declarative {
     using Icon = aui::ui_building::view<ADrawableView>;

--- a/aui.views/src/AUI/View/ALabel.h
+++ b/aui.views/src/AUI/View/ALabel.h
@@ -33,7 +33,7 @@ namespace declarative {
 template<>
 struct ADataBindingDefault<ALabel, AString> {
    public:
-    static void setup(const _<AString>& view) {
+    static void setup(const _<ALabel>& view) {
     }
 
     static auto getSetter() { return &ALabel::setText; }

--- a/aui.views/src/AUI/View/AText.h
+++ b/aui.views/src/AUI/View/AText.h
@@ -57,7 +57,10 @@ public:
     void setItems(const AVector<std::variant<AString, _<AView>>>& init, const Flags& flags = {});
     void clearContent();
     void setHtml(const AString& html, const Flags& flags = {});
-    void setString(const AString& string, const Flags& flags = {});
+    void setString(const AString& string, const Flags& flags);
+    void setString(const AString& string) {
+        setString(string, {});
+    }
 
     void render(ARenderContext context) override;
     void setSize(glm::ivec2 size) override;


### PR DESCRIPTION
- added `_<T>::operator()()` so `_<ADataBinding<T>>`'s `operator()()` can be easily accessed
- added `AListModel<T>::fromVector` `std::vector` overload
- `ADataBindingDefault<View, Data>::getGetter()` is now optional
- added data binding for `ADrawableView`
- fixed data binding for `ALabel`
- added `AText::setString` overload so it can be used with data binding