### PR TITLE
Feat/databinding extra overloads

### DIFF
--- a/aui.core/src/AUI/Traits/callables.h
+++ b/aui.core/src/AUI/Traits/callables.h
@@ -50,4 +50,16 @@ namespace aui {
 
     template<not_overloaded_lambda Lambda>
     using lambda_info = member<decltype(&Lambda::operator())>;
+
+    /**
+     * @brief Function object type whose `operator()` returns its argument unchanged.
+     * @details
+     * Implementation of std::identity.
+     */
+    struct identity
+    {
+        template<typename T>
+        [[nodiscard]]
+        constexpr T&& operator()(T&& t) const noexcept { return std::forward<T>(t); }
+    };
 }

--- a/aui.views/src/AUI/ASS/ASS.h
+++ b/aui.views/src/AUI/ASS/ASS.h
@@ -329,6 +329,7 @@
 #include "Property/Cursor.h"
 #include "Property/Expanding.h"
 #include "Property/FixedSize.h"
+#include "Property/Float.h"
 #include "Property/Font.h"
 #include "Property/FontFamily.h"
 #include "Property/FontRendering.h"

--- a/aui.views/src/AUI/ASS/Property/Float.cpp
+++ b/aui.views/src/AUI/ASS/Property/Float.cpp
@@ -1,0 +1,21 @@
+/*
+ * AUI Framework - Declarative UI toolkit for modern C++20
+ * Copyright (C) 2020-2024 Alex2772 and Contributors
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//
+// Created by alex2772 on 1/3/21.
+//
+
+#include "Float.h"
+
+
+void ass::prop::Property<AFloat>::applyFor(AView* view) {
+    view->setFloating(mInfo);
+}

--- a/aui.views/src/AUI/ASS/Property/Float.h
+++ b/aui.views/src/AUI/ASS/Property/Float.h
@@ -1,0 +1,37 @@
+/*
+ * AUI Framework - Declarative UI toolkit for modern C++20
+ * Copyright (C) 2020-2024 Alex2772 and Contributors
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <AUI/Util/AMetric.h>
+#include "IProperty.h"
+
+namespace ass {
+    namespace prop {
+        template<>
+        struct API_AUI_VIEWS Property<AFloat>: IPropertyBase {
+        private:
+            AFloat mInfo;
+
+        public:
+            Property(const AFloat& info) : mInfo(info) {
+
+            }
+
+            void applyFor(AView* view) override;
+
+            [[nodiscard]]
+            const auto& value() const noexcept {
+                return mInfo;
+            }
+        };
+    }
+}

--- a/aui.views/src/AUI/Enum/AFloat.h
+++ b/aui.views/src/AUI/Enum/AFloat.h
@@ -12,7 +12,7 @@
 #pragma once
 
 
-enum class Float {
+enum class AFloat {
     /**
      * Entry's default position behaviour.
      */

--- a/aui.views/src/AUI/Render/AMultilineTextRender.cpp
+++ b/aui.views/src/AUI/Render/AMultilineTextRender.cpp
@@ -23,8 +23,8 @@ void AMultilineTextRender::TextEntry::setPosition(const glm::ivec2& position) {
     mPosition = position;
 }
 
-Float AMultilineTextRender::TextEntry::getFloat() const {
-    return Float::NONE;
+AFloat AMultilineTextRender::TextEntry::getFloat() const {
+    return AFloat::NONE;
 }
 
 

--- a/aui.views/src/AUI/Render/AMultilineTextRender.h
+++ b/aui.views/src/AUI/Render/AMultilineTextRender.h
@@ -41,7 +41,7 @@ friend class TextEntry;
         }
         glm::ivec2 getSize() override;
         void setPosition(const glm::ivec2& position) override;
-        Float getFloat() const override;
+        AFloat getFloat() const override;
 
         ~TextEntry() override = default;
 

--- a/aui.views/src/AUI/Util/ADataBinding.h
+++ b/aui.views/src/AUI/Util/ADataBinding.h
@@ -211,7 +211,7 @@ public:
      */
     template<typename ModelField, typename SetterLambda>
     auto operator()(ModelField(Model::*field), SetterLambda setterLambda) {
-        using lambda_args = aui::lambda_info<SetterLambda>::args;
+        using lambda_args = typename aui::lambda_info<SetterLambda>::args;
         return aui::tuple_visitor<lambda_args>::for_each_all([&]<typename ViewReference, typename DataArgument>() {
             static_assert(std::is_reference_v<ViewReference>, "View is expected to be a reference");
             static_assert(aui::convertible_to<ModelField, DataArgument>, "lambda's argument is expected to be constructible from ModelField");
@@ -401,7 +401,7 @@ _<View> operator&&(const _<View>& object, const ADataBindingLinker2<Model, Data,
     ADataBindingDefault<View, Data>::setup(object);
 
     constexpr bool is_default_projection = std::is_same_v<Projection, std::nullptr_t>;
-    using projection_deduced = std::conditional_t<is_default_projection, std::identity, Projection>;
+    using projection_deduced = std::conditional_t<is_default_projection, aui::identity, Projection>;
     static_assert(std::is_invocable_v<projection_deduced, Data>, "projection is expected to accept Data value from model");
     using data_deduced = std::decay_t<std::invoke_result_t<projection_deduced, Data>>;
 

--- a/aui.views/src/AUI/Util/ADataBinding.h
+++ b/aui.views/src/AUI/Util/ADataBinding.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "AUI/Traits/concepts.h"
+#include <functional>
 #include <type_traits>
 #include <AUI/Common/SharedPtr.h>
 #include <AUI/Common/ASignal.h>

--- a/aui.views/src/AUI/Util/AViewEntry.cpp
+++ b/aui.views/src/AUI/Util/AViewEntry.cpp
@@ -29,8 +29,8 @@ void AViewEntry::setPosition(const glm::ivec2& position) {
 
 }
 
-Float AViewEntry::getFloat() const {
-    return Float::NONE;
+AFloat AViewEntry::getFloat() const {
+    return mView->getFloating();
 }
 
 AViewEntry::~AViewEntry() {

--- a/aui.views/src/AUI/Util/AViewEntry.h
+++ b/aui.views/src/AUI/Util/AViewEntry.h
@@ -24,7 +24,7 @@ public:
 
     glm::ivec2 getSize() override;
     void setPosition(const glm::ivec2& position) override;
-    Float getFloat() const override;
+    AFloat getFloat() const override;
 
     ~AViewEntry() override;
 };

--- a/aui.views/src/AUI/Util/AWordWrappingEngine.cpp
+++ b/aui.views/src/AUI/Util/AWordWrappingEngine.cpp
@@ -187,10 +187,9 @@ void AWordWrappingEngine::performLayout(const glm::ivec2& offset, const glm::ive
         }
         switch ((*currentItem)->getFloat()) {
             case AFloat::LEFT: {
-                leftFloat.push_back({*currentItem, currentItemSize.x, currentItemSize.y});
                 int position = ranges::accumulate(leftFloat, 0, std::plus<>{}, &FloatingEntry::occupiedHorizontalSpace);
+                leftFloat.push_back({*currentItem, currentItemSize.x, currentItemSize.y});
                 (*currentItem)->setPosition({position, currentY});
-                currentRowHeight = glm::max(currentRowHeight, currentItemSize.y);
                 break;
             }
 
@@ -198,7 +197,6 @@ void AWordWrappingEngine::performLayout(const glm::ivec2& offset, const glm::ive
                 rightFloat.push_back({*currentItem, currentItemSize.x, currentItemSize.y});
                 int position = ranges::accumulate(rightFloat, offset.x + size.x, std::minus<>{}, &FloatingEntry::occupiedHorizontalSpace);
                 (*currentItem)->setPosition({position, currentY});
-                currentRowHeight = glm::max(currentRowHeight, currentItemSize.y);
                 break;
             }
 

--- a/aui.views/src/AUI/Util/AWordWrappingEngine.cpp
+++ b/aui.views/src/AUI/Util/AWordWrappingEngine.cpp
@@ -13,6 +13,7 @@
 // Created by Alex2772 on 11/16/2021.
 //
 
+#include <range/v3/numeric/accumulate.hpp>
 #include <AUI/Traits/iterators.h>
 #include "AWordWrappingEngine.h"
 #include <algorithm>
@@ -185,27 +186,23 @@ void AWordWrappingEngine::performLayout(const glm::ivec2& offset, const glm::ive
             firstItem = false;
         }
         switch ((*currentItem)->getFloat()) {
-            case Float::LEFT: {
+            case AFloat::LEFT: {
                 leftFloat.push_back({*currentItem, currentItemSize.x, currentItemSize.y});
-                int position = 0;
-                for (auto it = leftFloat.begin(); it != leftFloat.end() - 1; ++it) {
-                    position += it->occupiedHorizontalSpace;
-                }
+                int position = ranges::accumulate(leftFloat, 0, std::plus<>{}, &FloatingEntry::occupiedHorizontalSpace);
                 (*currentItem)->setPosition({position, currentY});
+                currentRowHeight = glm::max(currentRowHeight, currentItemSize.y);
                 break;
             }
 
-            case Float::RIGHT: {
+            case AFloat::RIGHT: {
                 rightFloat.push_back({*currentItem, currentItemSize.x, currentItemSize.y});
-                int position = size.x;
-                for (auto it = rightFloat.begin(); it != rightFloat.end(); ++it) {
-                    position -= it->occupiedHorizontalSpace;
-                }
+                int position = ranges::accumulate(rightFloat, offset.x + size.x, std::minus<>{}, &FloatingEntry::occupiedHorizontalSpace);
                 (*currentItem)->setPosition({position, currentY});
+                currentRowHeight = glm::max(currentRowHeight, currentItemSize.y);
                 break;
             }
 
-            case Float::NONE:
+            case AFloat::NONE:
                 currentRow->push_back({*currentItem, currentItemSize.x});
                 currentRowHeight = glm::max(currentRowHeight, currentItemSize.y);
                 break;

--- a/aui.views/src/AUI/Util/AWordWrappingEngine.h
+++ b/aui.views/src/AUI/Util/AWordWrappingEngine.h
@@ -16,7 +16,7 @@
 #include <AUI/Common/AVector.h>
 #include <glm/glm.hpp>
 #include <AUI/Enum/ATextAlign.h>
-#include <AUI/Enum/Float.h>
+#include <AUI/Enum/AFloat.h>
 
 class API_AUI_VIEWS AWordWrappingEngine {
 public:
@@ -28,11 +28,11 @@ public:
         virtual void setPosition(const glm::ivec2& position) = 0;
 
         [[nodiscard]]
-        virtual Float getFloat() const = 0;
+        virtual AFloat getFloat() const = 0;
 
         [[nodiscard]]
         bool isFloating() const {
-            return getFloat() != Float::NONE;
+            return getFloat() != AFloat::NONE;
         }
 
         [[nodiscard]]

--- a/aui.views/src/AUI/View/AText.cpp
+++ b/aui.views/src/AUI/View/AText.cpp
@@ -169,6 +169,9 @@ int AText::getContentMinimumWidth(ALayoutDirection layout) {
     int accumulator = 0;
     for (const auto& e : mEngine.entries()) {
         if (accumulator + e->getSize().x > mMaxSize.x) {
+            if (accumulator == 0) {
+                return mMaxSize.x;
+            }
             // there's no need to calculate min size further.
             return accumulator;
         }
@@ -250,8 +253,8 @@ void AText::WordEntry::setPosition(const glm::ivec2& position) {
     mPosition = position;
 }
 
-Float AText::WordEntry::getFloat() const {
-    return Float::NONE;
+AFloat AText::WordEntry::getFloat() const {
+    return AFloat::NONE;
 }
 
 glm::ivec2 AText::WhitespaceEntry::getSize() {
@@ -262,8 +265,8 @@ void AText::WhitespaceEntry::setPosition(const glm::ivec2& position) {
 
 }
 
-Float AText::WhitespaceEntry::getFloat() const {
-    return Float::NONE;
+AFloat AText::WhitespaceEntry::getFloat() const {
+    return AFloat::NONE;
 }
 
 bool AText::WhitespaceEntry::escapesEdges() {
@@ -279,8 +282,8 @@ void AText::CharEntry::setPosition(const glm::ivec2& position) {
     mPosition = position;
 }
 
-Float AText::CharEntry::getFloat() const {
-    return Float::NONE;
+AFloat AText::CharEntry::getFloat() const {
+    return AFloat::NONE;
 }
 
 void AText::clearContent() {

--- a/aui.views/src/AUI/View/AText.h
+++ b/aui.views/src/AUI/View/AText.h
@@ -96,7 +96,7 @@ private:
 
         void setPosition(const glm::ivec2& position) override;
 
-        Float getFloat() const override;
+        AFloat getFloat() const override;
 
         const glm::ivec2& getPosition() const {
             return mPosition;
@@ -120,7 +120,7 @@ private:
 
         void setPosition(const glm::ivec2& position) override;
 
-        Float getFloat() const override;
+        AFloat getFloat() const override;
 
         const glm::ivec2& getPosition() const {
             return mPosition;
@@ -141,7 +141,7 @@ private:
 
         glm::ivec2 getSize() override;
         void setPosition(const glm::ivec2& position) override;
-        Float getFloat() const override;
+        AFloat getFloat() const override;
 
         bool escapesEdges() override;
 

--- a/aui.views/src/AUI/View/AView.h
+++ b/aui.views/src/AUI/View/AView.h
@@ -45,6 +45,7 @@
 #include <AUI/Event/APointerMoveEvent.h>
 #include <AUI/Render/ITexture.h>
 #include <AUI/Render/IRenderViewToTexture.h>
+#include <AUI/Enum/AFloat.h>
 
 
 class AWindow;
@@ -1010,6 +1011,23 @@ public:
         mSkipUntilLayoutUpdate = skipUntilLayoutUpdate;
     }
 
+    /**
+     * @brief Set floating value for AText.
+     */
+    void setFloating(AFloat f) noexcept
+    {
+        mFloating = f;
+    }
+
+    /**
+     * @brief Floating value for AText.
+     */
+    [[nodiscard]]
+    AFloat getFloating() const noexcept
+    {
+        return mFloating;
+    }
+
 signals:
     /**
      * @see onViewGraphSubtreeChanged()
@@ -1100,6 +1118,11 @@ private:
     bool mDirectlyEnabled = true;
     bool mParentEnabled = true;
     AFieldSignalEmitter<bool> mHasFocus = AFieldSignalEmitter<bool>(focusState, focusAcquired, focusLost, false);
+
+    /**
+     * @brief Floating value for AText.
+     */
+    AFloat mFloating = AFloat::NONE;
 
     struct RenderToTexture {
         _unique<IRenderViewToTexture> rendererInterface;

--- a/aui.views/tests/DataBinding.cpp
+++ b/aui.views/tests/DataBinding.cpp
@@ -1,0 +1,80 @@
+/*
+ * AUI Framework - Declarative UI toolkit for modern C++20
+ * Copyright (C) 2020-2024 Alex2772 and Contributors
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <gtest/gtest.h>
+#include "AUI/View/ALabel.h"
+
+namespace {
+    struct Model {
+        AString text;
+        int number = 0;
+    };
+}
+
+TEST(DataBinding, Setter) {
+    auto l = _new<ALabel>();
+    auto model = _new<ADataBinding<Model>>(Model{
+        .text = "text1"
+    });
+
+    l && model(&Model::text);
+
+    EXPECT_EQ(l->text(), "text1");
+
+    model->setValue(&Model::text, "text2");
+
+    EXPECT_EQ(l->text(), "text2");
+}
+
+TEST(DataBinding, SetterSpecifiedMember) {
+    auto l = _new<ALabel>();
+    auto model = _new<ADataBinding<Model>>(Model{
+        .text = "text1"
+    });
+
+    l && model(&Model::text, &ALabel::setText);
+
+    EXPECT_EQ(l->text(), "text1");
+
+    model->setValue(&Model::text, "text2");
+
+    EXPECT_EQ(l->text(), "text2");
+}
+
+TEST(DataBinding, SetterCustom) {
+    auto l = _new<ALabel>();
+    auto model = _new<ADataBinding<Model>>(Model{
+            .text = "text1"
+    });
+
+    l && model(&Model::text, [](ALabel& label, const AString& s) {
+        label.setText("{} custom"_format(s));
+    });
+
+    EXPECT_EQ(l->text(), "text1 custom");
+
+    model->setValue(&Model::text, "text2");
+
+    EXPECT_EQ(l->text(), "text2 custom");
+}
+
+TEST(DataBinding, SetterProjection) {
+    auto l = _new<ALabel>();
+    auto model = _new<ADataBinding<Model>>(Model{});
+
+    l && model(&Model::number, AString::number<int>);
+
+    EXPECT_EQ(l->text(), "0");
+
+    model->setValue(&Model::number, 2);
+
+    EXPECT_EQ(l->text(), "2");
+}

--- a/aui.views/tests/WordWrappingEngineTest.cpp
+++ b/aui.views/tests/WordWrappingEngineTest.cpp
@@ -96,6 +96,7 @@ TEST(WordWrappingEngine, SimpleLeftFloatRight1) {
     });
     engine.performLayout({0, 0}, {100, 100});
 }
+
 TEST(WordWrappingEngine, SimpleLeftFloatRight2) {
     AWordWrappingEngine engine;
     engine.setEntries(AVector<_<AWordWrappingEngine::Entry>>{
@@ -107,6 +108,7 @@ TEST(WordWrappingEngine, SimpleLeftFloatRight2) {
     });
     engine.performLayout({0, 0}, {100, 100});
 }
+
 TEST(WordWrappingEngine, SimpleLeftFloatBoth) {
     AWordWrappingEngine engine;
     engine.setEntries(AVector<_<AWordWrappingEngine::Entry>>{
@@ -135,6 +137,7 @@ TEST(WordWrappingEngine, SimpleRight) {
     engine.setTextAlign(ATextAlign::RIGHT);
     engine.performLayout({0, 0}, {100, 100});
 }
+
 TEST(WordWrappingEngine, SimpleCenter) {
     AWordWrappingEngine engine;
     engine.setEntries(AVector<_<AWordWrappingEngine::Entry>>{
@@ -146,6 +149,7 @@ TEST(WordWrappingEngine, SimpleCenter) {
     engine.setTextAlign(ATextAlign::CENTER);
     engine.performLayout({0, 0}, {100, 100});
 }
+
 TEST(WordWrappingEngine, SimpleJustify) {
     AWordWrappingEngine engine;
     engine.setEntries(AVector<_<AWordWrappingEngine::Entry>>{
@@ -153,6 +157,16 @@ TEST(WordWrappingEngine, SimpleJustify) {
             _new<MyEntry>(glm::ivec2{20, 15}, glm::ivec2{40, 0}),
             _new<MyEntry>(glm::ivec2{30, 10}, glm::ivec2{70, 0}),
             _new<MyEntry>(glm::ivec2{30, 10}, glm::ivec2{0, 15}),
+    });
+    engine.setTextAlign(ATextAlign::JUSTIFY);
+    engine.performLayout({0, 0}, {100, 100});
+}
+
+TEST(WordWrappingEngine, FloatingEntryConsumesHeight) {
+    AWordWrappingEngine engine;
+    engine.setEntries(AVector<_<AWordWrappingEngine::Entry>>{
+        _new<MyEntry>(glm::ivec2{30, 10}, glm::ivec2{0, 0}),
+        _new<FloatingEntry>(glm::ivec2{10, 100}, glm::ivec2{90, 0}, AFloat::RIGHT),
     });
     engine.setTextAlign(ATextAlign::JUSTIFY);
     engine.performLayout({0, 0}, {100, 100});

--- a/aui.views/tests/WordWrappingEngineTest.cpp
+++ b/aui.views/tests/WordWrappingEngineTest.cpp
@@ -35,21 +35,21 @@ public:
         EXPECT_NEAR(float(mExpectedPosition.y), float(position.y), 2.f);
     }
 
-    Float getFloat() const override {
-        return Float::NONE;
+    AFloat getFloat() const override {
+        return AFloat::NONE;
     }
 };
 
 class FloatingEntry: public MyEntry {
 private:
-    Float mFloating;
+    AFloat mFloating;
 
 public:
-    FloatingEntry(const glm::ivec2& size, const glm::ivec2& expectedPosition, Float floating) : MyEntry(size,
-                                                                                                        expectedPosition),
-                                                                                                mFloating(floating) {}
+    FloatingEntry(const glm::ivec2& size, const glm::ivec2& expectedPosition, AFloat floating) : MyEntry(size,
+                                                                                                         expectedPosition),
+                                                                                                 mFloating(floating) {}
 
-    Float getFloat() const override {
+    AFloat getFloat() const override {
         return mFloating;
     }
 };
@@ -68,7 +68,7 @@ TEST(WordWrappingEngine, SimpleLeft) {
 TEST(WordWrappingEngine, SimpleLeftFloatLeft) {
     AWordWrappingEngine engine;
     engine.setEntries(AVector<_<AWordWrappingEngine::Entry>>{
-        _new<FloatingEntry>(glm::ivec2{30, 20}, glm::ivec2{0, 0}, Float::LEFT),
+        _new<FloatingEntry>(glm::ivec2{30, 20}, glm::ivec2{0, 0}, AFloat::LEFT),
         _new<MyEntry>(glm::ivec2{20, 15}, glm::ivec2{30, 0}),
         _new<MyEntry>(glm::ivec2{30, 10}, glm::ivec2{50, 0}),
         _new<MyEntry>(glm::ivec2{30, 10}, glm::ivec2{30, 15}),
@@ -78,7 +78,7 @@ TEST(WordWrappingEngine, SimpleLeftFloatLeft) {
 TEST(WordWrappingEngine, SimpleLeftFloatLeftStartFromBeginning) {
     AWordWrappingEngine engine;
     engine.setEntries(AVector<_<AWordWrappingEngine::Entry>>{
-        _new<FloatingEntry>(glm::ivec2{30, 20}, glm::ivec2{0, 0}, Float::LEFT),
+        _new<FloatingEntry>(glm::ivec2{30, 20}, glm::ivec2{0, 0}, AFloat::LEFT),
         _new<MyEntry>(glm::ivec2{60, 15}, glm::ivec2{30, 0}),
         _new<MyEntry>(glm::ivec2{60, 15}, glm::ivec2{30, 15}),
         _new<MyEntry>(glm::ivec2{60, 0}, glm::ivec2{0, 30}),
@@ -89,7 +89,7 @@ TEST(WordWrappingEngine, SimpleLeftFloatLeftStartFromBeginning) {
 TEST(WordWrappingEngine, SimpleLeftFloatRight1) {
     AWordWrappingEngine engine;
     engine.setEntries(AVector<_<AWordWrappingEngine::Entry>>{
-            _new<FloatingEntry>(glm::ivec2{30, 20}, glm::ivec2{70, 0}, Float::RIGHT),
+            _new<FloatingEntry>(glm::ivec2{30, 20}, glm::ivec2{70, 0}, AFloat::RIGHT),
             _new<MyEntry>(glm::ivec2{20, 15}, glm::ivec2{00, 0}),
             _new<MyEntry>(glm::ivec2{30, 10}, glm::ivec2{20, 0}),
             _new<MyEntry>(glm::ivec2{30, 10}, glm::ivec2{00, 15}),
@@ -99,7 +99,7 @@ TEST(WordWrappingEngine, SimpleLeftFloatRight1) {
 TEST(WordWrappingEngine, SimpleLeftFloatRight2) {
     AWordWrappingEngine engine;
     engine.setEntries(AVector<_<AWordWrappingEngine::Entry>>{
-            _new<FloatingEntry>(glm::ivec2{30, 20}, glm::ivec2{70, 0}, Float::RIGHT),
+            _new<FloatingEntry>(glm::ivec2{30, 20}, glm::ivec2{70, 0}, AFloat::RIGHT),
             _new<MyEntry>(glm::ivec2{50, 15}, glm::ivec2{0, 00}),
             _new<MyEntry>(glm::ivec2{50, 20}, glm::ivec2{0, 15}),
             _new<MyEntry>(glm::ivec2{50, 10}, glm::ivec2{0, 35}),
@@ -110,8 +110,8 @@ TEST(WordWrappingEngine, SimpleLeftFloatRight2) {
 TEST(WordWrappingEngine, SimpleLeftFloatBoth) {
     AWordWrappingEngine engine;
     engine.setEntries(AVector<_<AWordWrappingEngine::Entry>>{
-            _new<FloatingEntry>(glm::ivec2{30, 20}, glm::ivec2{0, 0}, Float::LEFT),
-            _new<FloatingEntry>(glm::ivec2{30, 20}, glm::ivec2{70, 0}, Float::RIGHT),
+            _new<FloatingEntry>(glm::ivec2{30, 20}, glm::ivec2{0, 0}, AFloat::LEFT),
+            _new<FloatingEntry>(glm::ivec2{30, 20}, glm::ivec2{70, 0}, AFloat::RIGHT),
             _new<MyEntry>(glm::ivec2{20, 15}, glm::ivec2{30, 00}),
             _new<MyEntry>(glm::ivec2{20, 15}, glm::ivec2{50, 00}),
             _new<MyEntry>(glm::ivec2{20, 15}, glm::ivec2{30, 15}),

--- a/aui.views/tests/WordWrappingEngineTest.cpp
+++ b/aui.views/tests/WordWrappingEngineTest.cpp
@@ -168,6 +168,6 @@ TEST(WordWrappingEngine, FloatingEntryConsumesHeight) {
         _new<MyEntry>(glm::ivec2{30, 10}, glm::ivec2{0, 0}),
         _new<FloatingEntry>(glm::ivec2{10, 100}, glm::ivec2{90, 0}, AFloat::RIGHT),
     });
-    engine.setTextAlign(ATextAlign::JUSTIFY);
     engine.performLayout({0, 0}, {100, 100});
+    EXPECT_EQ(*engine.height(), 100);
 }


### PR DESCRIPTION
Related to #81

- added handy `ADataBinding` overloads
- added docs for `ADataBinding`
- `Float` -> `AFloat`
- `AViewEntry` now uses `AFloat`
- `AFloat` is now an ASS property
