### PR TITLE
Unresolved symbols in ASplitter::Builder

### DIFF
--- a/aui.views/src/AUI/View/ASplitter.h
+++ b/aui.views/src/AUI/View/ASplitter.h
@@ -90,7 +90,7 @@ public:
         return *this;
     }
 
-    _<AView> build();
+    API_AUI_VIEWS _<AView> build();
 
     operator _<AView>() {
         return build();


### PR DESCRIPTION
With the PR #383 merged, there was an unresolved symbol error in `ASplitter::Builder` when compiling my project. This PR tries to fix it.

BTW, the new splitter works really well now for my use case!