### PR TITLE
Feat/property system fixes

### DIFF
--- a/aui.core/src/AUI/Common/AObject.h
+++ b/aui.core/src/AUI/Common/AObject.h
@@ -36,7 +36,7 @@ namespace aui::detail {
  * AObject keeps reference to itself via std::enable_shared_from_this. It can be accessed with sharedPtr() and weakPtr()
  * functions.
  */
-class API_AUI_CORE AObject: public AObjectBase, public std::enable_shared_from_this<AObject> {
+class API_AUI_CORE AObject: public AObjectBase, public std::enable_shared_from_this<AObject>, public aui::noncopyable {
     friend class AAbstractSignal;
     template <typename ... Args>
     friend class ASignal;

--- a/aui.core/src/AUI/Common/AObjectBase.h
+++ b/aui.core/src/AUI/Common/AObjectBase.h
@@ -28,8 +28,10 @@ class API_AUI_CORE AObjectBase {
     /* tests */
     friend class SignalSlotTest;
     friend class PropertyTest;
+    friend class PropertyPrecomputedTest;
 
 public:
+    virtual ~AObjectBase() = default;
     AObjectBase() = default;
 
     static ASpinlockMutex SIGNAL_SLOT_GLOBAL_SYNC;

--- a/aui.core/src/AUI/Common/AObjectBase.h
+++ b/aui.core/src/AUI/Common/AObjectBase.h
@@ -21,12 +21,13 @@
 #include "SharedPtrTypes.h"
 #include <AUI/Common/AAbstractSignal.h>
 
-class API_AUI_CORE AObjectBase : public aui::noncopyable {
+class API_AUI_CORE AObjectBase {
     /* ASignal <-> AObject implementation stuff */
     friend class AAbstractSignal;
 
     /* tests */
     friend class SignalSlotTest;
+    friend class UIDataBindingTest;
 
 public:
     AObjectBase() = default;
@@ -34,7 +35,24 @@ public:
     static ASpinlockMutex SIGNAL_SLOT_GLOBAL_SYNC;
 
     AObjectBase(AObjectBase&& rhs) noexcept {
+        operator=(std::move(rhs));
+    }
+
+    AObjectBase(const AObjectBase& rhs) noexcept {
+        // mIngoingConnections are not borrowed on copy operation.
+    }
+
+    AObjectBase& operator=(const AObjectBase& rhs) noexcept {
+        // mIngoingConnections are not borrowed on copy operation.
+        return *this;
+    }
+
+    AObjectBase& operator=(AObjectBase&& rhs) noexcept {
+        if (this == &rhs) {
+            return *this;
+        }
         AUI_ASSERTX(rhs.mIngoingConnections.empty(), "AObjectBase move is valid only if no signals connected to it");
+        return *this;
     }
 
 protected:

--- a/aui.core/src/AUI/Common/AObjectBase.h
+++ b/aui.core/src/AUI/Common/AObjectBase.h
@@ -27,7 +27,7 @@ class API_AUI_CORE AObjectBase {
 
     /* tests */
     friend class SignalSlotTest;
-    friend class UIDataBindingTest;
+    friend class PropertyTest;
 
 public:
     AObjectBase() = default;

--- a/aui.core/src/AUI/Common/AProperty.h
+++ b/aui.core/src/AUI/Common/AProperty.h
@@ -170,6 +170,28 @@ struct AProperty: AObjectBase {
         return this;
     }
 
+    AProperty(const AProperty& value): raw(value.raw) {
+    }
+
+    AProperty(AProperty&& value) noexcept: raw(std::move(value.raw)) {
+    }
+
+    AProperty& operator=(const AProperty& value) {
+        if (this == &value) {
+            return *this;
+        }
+        operator=(value.raw);
+        return *this;
+    }
+
+    AProperty& operator=(AProperty&& value) noexcept {
+        if (this == &value) {
+            return *this;
+        }
+        operator=(std::move(value.raw));
+        return *this;
+    }
+
     template <aui::convertible_to<T> U>
     AProperty& operator=(U&& value) noexcept {
         static constexpr auto IS_COMPARABLE = requires { this->raw == value; };
@@ -179,13 +201,20 @@ struct AProperty: AObjectBase {
             }
         }
         this->raw = std::forward<U>(value);
-        emit changed(this->raw);
+        notify();
         return *this;
     }
 
     template <ASignalInvokable SignalInvokable>
     void operator^(SignalInvokable&& t) {
         t.invokeSignal(nullptr);
+    }
+
+    /**
+     * @brief Notify observers that a change was occurred (no preconditions).
+     */
+    void notify() {
+        emit changed(this->raw);
     }
 
     [[nodiscard]]

--- a/aui.core/src/AUI/Common/AProperty.h
+++ b/aui.core/src/AUI/Common/AProperty.h
@@ -163,6 +163,7 @@ struct AProperty: AObjectBase {
     }
 
     AProperty(AProperty&& value) noexcept: raw(std::move(value.raw)) {
+        value.notify();
     }
 
     AProperty& operator=(const AProperty& value) {
@@ -178,6 +179,7 @@ struct AProperty: AObjectBase {
             return *this;
         }
         operator=(std::move(value.raw));
+        value.notify();
         return *this;
     }
 

--- a/aui.core/src/AUI/Common/AProperty.h
+++ b/aui.core/src/AUI/Common/AProperty.h
@@ -145,7 +145,7 @@ template <typename T>
 struct AProperty: AObjectBase {
     using Underlying = T;
 
-    T raw;
+    T raw{};
     emits<T> changed;
 
     AProperty()

--- a/aui.core/src/AUI/Common/AProperty.h
+++ b/aui.core/src/AUI/Common/AProperty.h
@@ -139,18 +139,7 @@ auto makeBidirectionalProjection(Property&& property, Projection&& projection) {
  * `AProperty<T>` is a container holding an instance of `T`. You can assign a value to it with `operator=` and read
  * value with `value()` method or implicit conversion `operator T()`.
  *
- * See @ref property_system "property system" for more info.
- * @code{cpp}
- * struct User {
- *   AProperty<AString> name;
- *   AProperty<AString> surname;
- * };
- *
- * // AProperty behaves like a class/struct data member:
- * User u;
- * u.name = "Hello";
- * EXPECT_EQ(u.name, "Hello");
- * @endcode
+ * See @ref property_system "property system" for usage examples.
  */
 template <typename T>
 struct AProperty: AObjectBase {
@@ -247,7 +236,7 @@ struct AProperty: AObjectBase {
     }
 
     /**
-     * @brief Makes a readonly projection of this property.
+     * @brief Makes a readonly @ref UIDataBindingTest_Label_via_declarative_projection "projection" of this property.
      */
     template<aui::invocable<const T&> Projection>
     [[nodiscard]]
@@ -256,7 +245,7 @@ struct AProperty: AObjectBase {
     }
 
     /**
-     * @brief Makes a bidirectional projection of this property.
+     * @brief Makes a bidirectional @ref UIDataBindingTest_Label_via_declarative_projection "projection" of this property.
      */
     template<aui::invocable<const T&> ProjectionRead,
              aui::invocable<const std::invoke_result_t<ProjectionRead, T>&> ProjectionWrite>
@@ -292,9 +281,12 @@ static_assert(AAnyProperty<AProperty<int>>, "AProperty does not conform AAnyProp
  * @brief Property implementation to use with custom getter/setter.
  * @ingroup property_system
  * @details
- * See @ref property_system "property system" for more info.
+ * You can use this way if you are required to define custom behaviour on getter/setter. As a downside, you have to
+ * write extra boilerplate code: define property, data field, signal, getter and setter checking equality. Also,
+ * APropertyDef requires the class to derive `AObject`. Most of AView's properties are defined this way.
  *
- * @snippet aui.uitests/tests/UIDataBindingTest.cpp APropertyDef User
+ * See @ref property_system "property system" for usage examples.
+ *
  * # Performance considerations
  * APropertyDef [does not involve](https://godbolt.org/z/cYTrc3PPf ) extra runtime overhead between assignment and
  * getter/setter.
@@ -383,7 +375,7 @@ struct APropertyDef {
     }
 
     /**
-     * @brief Makes a readonly projection of this property.
+     * @brief Makes a readonly @ref UIDataBindingTest_Label_via_declarative_projection "projection" of this property.
      */
     template <aui::invocable<const Underlying&> Projection>
     [[nodiscard]]
@@ -392,7 +384,7 @@ struct APropertyDef {
     }
 
     /**
-     * @brief Makes a bidirectional projection of this property.
+     * @brief Makes a bidirectional @ref UIDataBindingTest_Label_via_declarative_projection "projection" of this property.
      */
     template <
         aui::invocable<const Underlying&> ProjectionRead,

--- a/aui.core/src/AUI/Common/APropertyPrecomputed.h
+++ b/aui.core/src/AUI/Common/APropertyPrecomputed.h
@@ -80,8 +80,8 @@ struct APropertyPrecomputed final : aui::property_precomputed::detail::Dependenc
 
     }
 
-    // APropertyPrecomputed(const APropertyPrecomputed&) = delete;
-    // APropertyPrecomputed(APropertyPrecomputed&&) noexcept = delete;
+    APropertyPrecomputed(const APropertyPrecomputed&) = delete;
+    APropertyPrecomputed(APropertyPrecomputed&&) noexcept = delete;
 
     template <ASignalInvokable SignalInvokable>
     void operator^(SignalInvokable&& t) {

--- a/aui.core/src/AUI/Common/APropertyPrecomputed.h
+++ b/aui.core/src/AUI/Common/APropertyPrecomputed.h
@@ -80,8 +80,8 @@ struct APropertyPrecomputed final : aui::property_precomputed::detail::Dependenc
 
     }
 
-    APropertyPrecomputed(const APropertyPrecomputed&) = delete;
-    APropertyPrecomputed(APropertyPrecomputed&&) noexcept = delete;
+    // APropertyPrecomputed(const APropertyPrecomputed&) = delete;
+    // APropertyPrecomputed(APropertyPrecomputed&&) noexcept = delete;
 
     template <ASignalInvokable SignalInvokable>
     void operator^(SignalInvokable&& t) {

--- a/aui.core/src/AUI/Common/APropertyPrecomputed.h
+++ b/aui.core/src/AUI/Common/APropertyPrecomputed.h
@@ -45,20 +45,26 @@ API_AUI_CORE void addDependency(const AAbstractSignal& signal);
  * `APropertyPrecomputed<T>` is a readonly property similar to `AProperty<T>`. It holds an instance of `T` as well.
  * Its value is determined by the C++ function specified in its constructor, typically a C++ lambda expression.
  *
- * See @ref property_system "property system" for more info.
- * @example
- * @code{cpp}
- * struct User {
- *     AProperty<AString> name;
- *     AProperty<AString> surname;
- *     APropertyPrecomputed<AString> fullName = [&] { return "{} {}"_format(name, surname); };
- * };
- * auto u = aui::ptr::manage(new User {
- *   .name = "Emma",
- *   .surname = "Watson",
- * });
- * EXPECT_EQ(u->fullName, "Emma Watson");
- * @endcode
+ * See @ref property_system "property system" for usage info.
+ *
+ * Despite properties offer @ref UIDataBindingTest_Label_via_declarative_projection "projection methods", you might
+ * want to track and process values of several properties.
+ *
+ * `APropertyPrecomputed<T>` is a readonly property similar to `AProperty<T>`. It holds an instance of `T` as well.
+ * Its value is determined by the C++ function specified in its constructor, typically a C++ lambda expression.
+ *
+ * It's convenient to access values from another properties inside the expression. The properties accessed during
+ * invocation of the expression are tracked behind the scenes so they become dependencies of `APropertyPrecomputed`
+ * automatically. If one of the tracked properties fires `changed` signal, `APropertyPrecomputed` invalidates its
+ * `T`. `APropertyPrecomputed` follows @ref aui::lazy "lazy semantics" so the expression is re-evaluated and the new
+ * result is applied to `APropertyPrecomputed` as soon as the latter is accessed for the next time.
+ *
+ * In other words, it allows to specify relationships between different object properties and reactively update
+ * `APropertyPrecomputed` value whenever its dependencies change. `APropertyPrecomputed<T>` is somewhat similar to
+ * [Qt Bindable Properties](https://doc.qt.io/qt-6/bindableproperties.html).
+ *
+ * `APropertyPrecomputed` is a readonly property, hence you can't update its value with assignment. You can get its
+ * value with `value()` method or implicit conversion `operator T()` as with other properties.
  */
 template<typename T>
 struct APropertyPrecomputed final : aui::property_precomputed::detail::DependencyObserver {

--- a/aui.core/src/AUI/Common/ASignal.h
+++ b/aui.core/src/AUI/Common/ASignal.h
@@ -151,6 +151,7 @@ class ASignal final : public AAbstractSignal {
 
     /* tests */
     friend class UIDataBindingTest_APropertyPrecomputed_Complex_Test;
+    friend class UIDataBindingTest;
     friend class SignalSlotTest;
 
     template <typename AnySignal, typename Projection>
@@ -179,7 +180,15 @@ public:
 
     ASignal() = default;
     ASignal(ASignal&&) noexcept = default;
-    ASignal(const ASignal&) = delete;
+    ASignal(const ASignal&) noexcept {
+        // mOutgoingConnections are not borrowed on copy operation.
+    }
+
+    ASignal& operator=(ASignal&&) noexcept = default;
+    ASignal& operator=(const ASignal&) noexcept {
+        // mOutgoingConnections are not borrowed on copy operation.
+        return *this;
+    }
 
     virtual ~ASignal() noexcept = default;
 

--- a/aui.core/src/AUI/Common/ASignal.h
+++ b/aui.core/src/AUI/Common/ASignal.h
@@ -150,9 +150,9 @@ class ASignal final : public AAbstractSignal {
     friend class AObject;
 
     /* tests */
-    friend class UIDataBindingTest_APropertyPrecomputed_Complex_Test;
-    friend class UIDataBindingTest;
+    friend class PropertyPrecomputedTest_APropertyPrecomputed_Complex_Test;
     friend class SignalSlotTest;
+    friend class PropertyTest;
 
     template <typename AnySignal, typename Projection>
     friend struct aui::detail::signal::ProjectedSignal;

--- a/aui.core/src/AUI/Common/ASignal.h
+++ b/aui.core/src/AUI/Common/ASignal.h
@@ -153,6 +153,7 @@ class ASignal final : public AAbstractSignal {
     friend class PropertyPrecomputedTest_APropertyPrecomputed_Complex_Test;
     friend class SignalSlotTest;
     friend class PropertyTest;
+    friend class PropertyPrecomputedTest;
 
     template <typename AnySignal, typename Projection>
     friend struct aui::detail::signal::ProjectedSignal;

--- a/aui.core/src/AUI/Common/AString.h
+++ b/aui.core/src/AUI/Common/AString.h
@@ -640,15 +640,15 @@ public:
         return *this;
     }
 
-    const AString& operator=(const AString& value) noexcept
+    AString& operator=(const AString& value) noexcept
     {
         super::operator=(value);
         return *this;
     }
 
-    const AString& operator=(AString&& value) noexcept
+    AString& operator=(AString&& value) noexcept
     {
-        super::operator=(value);
+        super::operator=(std::move(value));
         return *this;
     }
 

--- a/aui.core/tests/PropertyCommonTest.cpp
+++ b/aui.core/tests/PropertyCommonTest.cpp
@@ -1,0 +1,196 @@
+// AUI Framework - Declarative UI toolkit for modern C++20
+// Copyright (C) 2020-2024 Alex2772 and Contributors
+//
+// SPDX-License-Identifier: MPL-2.0
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <AUI/Common/AObject.h>
+#include <AUI/Common/ASignal.h>
+#include <AUI/Util/kAUI.h>
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include "AUI/Common/AProperty.h"
+
+namespace {
+struct User {
+    AProperty<AString> name;
+};
+
+
+class Receiver: public AObject {
+public:
+    MOCK_METHOD(void, receiveStr, (const AString& msg));
+    MOCK_METHOD(void, receiveInt, (int msg));
+};
+}
+
+TEST(PropertyCommonTest, DesignatedInitializer) {
+    auto u = aui::ptr::manage(new User { .name = "Hello" });
+    EXPECT_EQ(u->name, "Hello");
+}
+
+TEST(PropertyCommonTest, ValueCanBeChanged) {
+    auto u = aui::ptr::manage(new User { .name = "Hello" });
+    u->name = "World";
+
+    // this should not compile
+    // u->name = {"World"};
+
+    EXPECT_EQ(u->name, "World");
+}
+
+TEST(PropertyCommonTest, ValueCanBePassed) {
+    auto u = aui::ptr::manage(new User { .name = "Hello" });
+    auto stringIdentity = [](const AString& value) {
+        return value;
+    };
+    EXPECT_EQ(stringIdentity(u->name), "Hello");
+}
+
+TEST(PropertyCommonTest, ValueOperatorArrow) {
+    auto u = aui::ptr::manage(new User { .name = "Hello" });
+    EXPECT_EQ(u->name->length(), 5);
+}
+
+TEST(PropertyCommonTest, ChangedSignal) {
+    auto u = aui::ptr::manage(new User { .name = "Hello" });
+    auto receiver = _new<Receiver>();
+    AObject::connect(u->name.changed, slot(receiver)::receiveStr);
+
+    EXPECT_CALL(*receiver, receiveStr(AString("World")));
+    u->name = "World";
+}
+
+TEST(PropertyCommonTest, PropertyConnection) {
+    auto receiver = _new<Receiver>();
+    auto u = aui::ptr::manage(new User { .name = "Hello" });
+
+    EXPECT_CALL(*receiver, receiveStr(AString("Hello"))).Times(1);
+    AObject::connect(u->name, slot(receiver)::receiveStr);
+
+    EXPECT_CALL(*receiver, receiveStr(AString("World"))).Times(1);
+    u->name = "World";
+}
+
+TEST(PropertyCommonTest, PropertyConnectionWithProjection1) {
+    auto receiver = _new<Receiver>();
+    auto u = aui::ptr::manage(new User { .name = "Hello" });
+
+    EXPECT_CALL(*receiver, receiveInt(5)).Times(1);
+    AObject::connect(u->name.readProjected(&AString::length), slot(receiver)::receiveInt);
+
+    EXPECT_CALL(*receiver, receiveInt(6)).Times(1);
+    u->name = "World!";
+}
+
+TEST(PropertyCommonTest, PropertyConnectionWithProjection2) {
+    auto receiver = _new<Receiver>();
+    auto u = aui::ptr::manage(new User { .name = "Hello" });
+
+    EXPECT_CALL(*receiver, receiveInt(5)).Times(1);
+    AObject::connect(u->name.readProjected([](const AString& s) { return s.length(); }), slot(receiver)::receiveInt);
+
+    EXPECT_CALL(*receiver, receiveInt(6)).Times(1);
+    u->name = "World!";
+}
+
+namespace {
+class CustomSetter : public AObject {
+public:
+    CustomSetter() {
+        ON_CALL(*this, setName(testing::_)).WillByDefault([&](const AString& s) {
+            emit nameChanged(s);
+        });
+    }
+
+    auto name() const {
+        return APropertyDef {
+            this,
+            &CustomSetter::getName,
+            &CustomSetter::setName,
+            nameChanged,
+        };
+    }
+
+    MOCK_METHOD(void, setName, (const AString& msg));
+
+private:
+    emits<AString> nameChanged;
+
+    AString getName() const { return "can't change"; }
+};
+}
+
+TEST(PropertyCommonTest, CustomSetter) {
+    CustomSetter u;
+    Receiver receiver;
+
+    static_assert(AAnyProperty<decltype(u.name())>);
+
+    EXPECT_CALL(u, setName(AString("World")));
+    EXPECT_CALL(receiver, receiveStr(AString("World")));
+
+    AObject::connect(u.name().changed, slot(receiver)::receiveStr);
+
+    u.name() = "World";
+    EXPECT_EQ(AString(u.name()), "can't change");
+}
+
+TEST(PropertyCommonTest, CustomSetterProperty) {
+    CustomSetter u;
+    auto receiver = _new<Receiver>();
+
+    EXPECT_CALL(u, setName(AString("World")));
+    EXPECT_CALL(*receiver, receiveStr(AString("can't change"))).Times(1);
+    EXPECT_CALL(*receiver, receiveStr(AString("World"))).Times(1);
+
+    AObject::connect(u.name(), slot(receiver)::receiveStr);
+
+    u.name() = "World";
+    EXPECT_EQ(AString(u.name()), "can't change");
+}
+
+TEST(PropertyCommonTest, Property2PropertyBoth) {
+    auto u = aui::ptr::manage(new User { .name = "initial" });
+    auto r = _new<CustomSetter>();
+
+    EXPECT_CALL(*r, setName(AString("initial"))).Times(1);
+    AObject::biConnect(u->name, r->name());
+
+    EXPECT_CALL(*r, setName(AString("New Name1"))).Times(1);
+    u->name = "New Name1";
+
+    EXPECT_CALL(*r, setName(AString("New Name2"))).Times(2); // expected to call 2 times: 1st time by calling setName
+    r->setName("New Name2");                                 // here; 2nd time as a loopback response from u
+
+    // the setName "New Name2" call above should reflect its change to u.
+    EXPECT_EQ(u->name, "New Name2");
+
+    // death of r should clear the link with u->name.
+    r = nullptr;
+    u->name = "Should not crash";
+}
+
+TEST(PropertyCommonTest, Property2PropertySetOnly) {
+    auto u = aui::ptr::manage(new User { .name = "initial" });
+    auto r = _new<CustomSetter>();
+
+    EXPECT_CALL(*r, setName(AString("initial"))).Times(1);
+    AObject::connect(u->name, r->name());
+
+    EXPECT_CALL(*r, setName(AString("New Name1"))).Times(1);
+    u->name = "New Name1";
+
+    EXPECT_CALL(*r, setName(AString("New Name2"))).Times(1);
+    r->setName("New Name2");
+
+    // the setName "New Name2" call above should NOT reflect its change to u.
+    EXPECT_EQ(u->name, "New Name1");
+
+    // death of r should clear the link with u->name.
+    r = nullptr;
+    u->name = "Should not crash";
+}

--- a/aui.core/tests/PropertyDefTest.cpp
+++ b/aui.core/tests/PropertyDefTest.cpp
@@ -1,0 +1,190 @@
+// AUI Framework - Declarative UI toolkit for modern C++20
+// Copyright (C) 2020-2024 Alex2772 and Contributors
+//
+// SPDX-License-Identifier: MPL-2.0
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <AUI/Common/AProperty.h>
+#include <AUI/Logging/ALogger.h>
+#include <AUI/Util/kAUI.h>
+#include <gmock/gmock.h>
+
+class PropertyDefTest : public testing::Test {
+public:
+    /*
+        template<typename... Args>
+        static auto& connections(ASignal<Args...>& signal) {
+            return signal.mOutgoingConnections;
+        }
+
+        static auto& connections(AObject& object) {
+            return object.mIngoingConnections;
+        }*/
+};
+
+namespace {
+// AUI_DOCS_OUTPUT: doxygen/intermediate/property_def.h
+// @class APropertyDef
+// # Declaration
+//
+// To declare a property with custom getter/setter, use APropertyDef template. APropertyDef-based property is
+// defined by const member function as follows:
+// AUI_DOCS_CODE_BEGIN
+class User : public AObject {
+public:
+    auto name() const {
+        return APropertyDef {
+            this,
+            &User::getName,   // this works too: &User::mName
+            &User::setName,
+            mNameChanged,
+        };
+    }
+
+private:
+    AString mName;
+    emits<AString> mNameChanged;
+
+    void setName(AString name) {
+        // APropertyDef requires us to emit
+        // changed signal if value is actually
+        // changed
+        if (mName == name) {
+            return;
+        }
+        mName = std::move(name);
+        emit mNameChanged(mName);
+    }
+
+    const AString& getName() const { return mName; }
+};
+// AUI_DOCS_CODE_END
+
+class LogObserver : public AObject {
+public:
+    LogObserver() {
+        ON_CALL(*this, log(testing::_)).WillByDefault([](const AString& msg) {});
+    }
+    MOCK_METHOD(void, log, (const AString& msg), ());
+};
+}   // namespace
+
+TEST_F(PropertyDefTest, Declaration) {
+    // APropertyDef behaves like a class/struct function member:
+    {
+        // AUI_DOCS_CODE_BEGIN
+        User u;
+        u.name() = "Hello";
+        EXPECT_EQ(u.name(), "Hello");
+        // AUI_DOCS_CODE_END
+    }
+    // @note
+    // Properties defined with APropertyDef instead of AProperty impersonate themselves by trailing braces `()`. We
+    // can't get rid of them, as APropertyDef is defined thanks to member function. In comparison to `user->name`, think
+    // of `user->name()` as the same kind of property except defining custom behaviour via function, hence the braces
+    // `()`.
+    //
+    // For the rest, APropertyDef is identical to AProperty including seamless interaction:
+    {
+        // AUI_DOCS_CODE_BEGIN
+        User u;
+        u.name() = "Hello";
+        u.name() += " world!";
+        EXPECT_EQ(u.name(), "Hello world!");
+        EXPECT_EQ(u.name()->length(), AString("Hello world!").length());
+        // AUI_DOCS_CODE_END
+        //
+        // @note
+        // In order to honor getters/setters, `APropertyDef` calls getter/setter instead of using `+=` on your property
+        // directly. Equivalent code will be:
+        // @code{cpp}
+        // u.setName(u.getName() + " world!")
+        // @endcode
+        //
+    }
+
+    {
+        // The implicit conversions work the same way as with AProperty:
+        // AUI_DOCS_CODE_BEGIN
+        auto doSomethingWithName = [](const AString& name) { EXPECT_EQ(name, "Hello"); };
+        User u;
+        u.name() = "Hello";
+        doSomethingWithName(u.name());
+        // AUI_DOCS_CODE_END
+
+        // If it doesn't, simply put an asterisk:
+        // AUI_DOCS_CODE_BEGIN
+        doSomethingWithName(*u.name());
+        //                 ^^^ HERE
+        // AUI_DOCS_CODE_END
+    }
+}
+
+TEST_F(PropertyDefTest, Observing_changes) { // HEADER_H1
+    // All property types offer `.changed` field which is a signal reporting value changes. Let's make little observer
+    // object for demonstration:
+    {
+        // AUI_DOCS_CODE_BEGIN
+        class LogObserver : public AObject {
+        public:
+            void log(const AString& msg) {
+                ALogger::info("LogObserver") << "Received value: " << msg;
+            }
+        };
+        // AUI_DOCS_CODE_END
+    }
+    // The usage is close to `AProperty`:
+    {
+        // AUI_DOCS_CODE_BEGIN
+        auto observer = _new<LogObserver>();
+        auto u = _new<User>();
+        u->name() = "Chloe";
+        // ...
+        AObject::connect(u->name().changed, slot(observer)::log);
+        // AUI_DOCS_CODE_END
+        EXPECT_CALL(*observer, log(AString("Marinette")));
+        // AUI_DOCS_CODE_BEGIN
+        u->name() = "Marinette";
+        // AUI_DOCS_CODE_END
+        // Code produces the following output:
+        // @code
+        // [07:58:59][][LogObserver][INFO]: Received value: Marinette
+        // @endcode
+    }
+    {
+        testing::InSequence s;
+        //
+        // Making connection to property directly instead of `.changed`:
+        // AUI_DOCS_CODE_BEGIN
+        auto observer = _new<LogObserver>();
+        EXPECT_CALL(*observer, log(AString("Chloe"))).Times(1);       // HIDE
+        EXPECT_CALL(*observer, log(AString("Marinette"))).Times(1);   // HIDE
+        auto u = _new<User>();
+        u->name() = "Chloe";
+        // ...
+        AObject::connect(u->name(), slot(observer)::log);
+        // AUI_DOCS_CODE_END
+        // Code above produces the following output:
+        // @code
+        // [07:58:59][][LogObserver][INFO]: Received value: Chloe
+        // @endcode
+        //
+        // Subsequent changes to field would send updates as well:
+        // AUI_DOCS_CODE_BEGIN
+        u->name() = "Marinette";
+        // AUI_DOCS_CODE_END
+        // Assignment operation above makes an additional line to output:
+        // @code
+        // [07:58:59][][LogObserver][INFO]: Received value: Marinette
+        // @endcode
+        //
+        // Whole program output when connecting to property directly:
+        // @code
+        // [07:58:59][][LogObserver][INFO]: Received value: Chloe
+        // [07:58:59][][LogObserver][INFO]: Received value: Marinette
+        // @endcode
+    }
+}

--- a/aui.core/tests/PropertyPrecomputed.cpp
+++ b/aui.core/tests/PropertyPrecomputed.cpp
@@ -1,0 +1,145 @@
+// AUI Framework - Declarative UI toolkit for modern C++20
+// Copyright (C) 2020-2024 Alex2772 and Contributors
+//
+// SPDX-License-Identifier: MPL-2.0
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <AUI/Common/AProperty.h>
+#include <AUI/Logging/ALogger.h>
+#include <AUI/Util/kAUI.h>
+#include <gmock/gmock.h>
+
+class PropertyPrecomputedTest : public testing::Test {
+public:
+    /*
+        template<typename... Args>
+        static auto& connections(ASignal<Args...>& signal) {
+            return signal.mOutgoingConnections;
+        }
+
+        static auto& connections(AObject& object) {
+            return object.mIngoingConnections;
+        }*/
+};
+
+namespace {
+// AUI_DOCS_OUTPUT: doxygen/intermediate/property_precomputed.h
+// @class APropertyPrecomputed
+// # Declaration
+// Declare a property with custom expression determining it's value as follows:
+// AUI_DOCS_CODE_BEGIN
+struct User {
+    AProperty<AString> name;
+    AProperty<AString> surname;
+    APropertyPrecomputed<AString> fullName = [&] { return "{} {}"_format(name, surname); };
+};
+// AUI_DOCS_CODE_END
+
+class LogObserver : public AObject {
+public:
+    LogObserver() {
+        ON_CALL(*this, log(testing::_)).WillByDefault([](const AString& msg) {});
+    }
+    MOCK_METHOD(void, log, (const AString& msg), ());
+};
+}
+
+TEST_F(PropertyPrecomputedTest, APropertyPrecomputed) {
+    // Let's make little observer object for demonstration:
+    {
+        // AUI_DOCS_CODE_BEGIN
+        class LogObserver : public AObject {
+        public:
+            void log(const AString& msg) {
+                ALogger::info("LogObserver") << "Received value: " << msg;
+            }
+        };
+        // AUI_DOCS_CODE_END
+    }
+    testing::InSequence s;
+
+    // Usage:
+    // AUI_DOCS_CODE_BEGIN
+    auto u = aui::ptr::manage(new User {
+        .name = "Emma",
+        .surname = "Watson",
+    });
+
+    auto observer = _new<LogObserver>();
+    EXPECT_CALL(*observer, log(AString("Emma Watson"))).Times(1);
+    AObject::connect(u->fullName, slot(observer)::log);
+    // AUI_DOCS_CODE_END
+    EXPECT_EQ(u->fullName, "Emma Watson");
+    //
+    // The example above prints "Emma Watson". If we try to update one of dependencies of `APropertyPrecomputed` (i.e.,
+    // `name` or `surname`), `APropertyPrecomputed` responds immediately:
+
+    // AUI_DOCS_CODE_BEGIN
+    EXPECT_CALL(*observer, log(AString("Emma Stone"))).Times(1);
+    u->surname = "Stone";
+    // AUI_DOCS_CODE_END
+    //
+    // The example above prints "Emma Stone".
+    EXPECT_EQ(u->fullName, "Emma Stone");
+}
+
+TEST_F(PropertyPrecomputedTest, APropertyPrecomputed_Complex) {
+    //
+    // ### Valid Expressions
+    // Any C++ callable evaluating to `T` can be used as an expression for `APropertyPrecomputed<T>`. However, to
+    // formulate correct expression, some rules must be satisfied.
+    //
+    // Dependency tracking only works on other properties. It is the developer's responsibility to ensure all values
+    // referenced in the expression are properties, or, at least, non-property values that wouldn't change or whose
+    // changes are not interesting. You definitely can use branching inside the expression, but you must be confident
+    // about what are you doing. Generally speaking, use as trivial expressions as possible.
+    //
+    // AUI_DOCS_CODE_BEGIN
+    struct User {
+        AProperty<AString> name;
+        AProperty<AString> surname;
+        APropertyPrecomputed<AString> fullName = [&]() -> AString {
+            if (name->empty()) {
+                return "-";
+            }
+            if (surname->empty()) {
+                return "-";
+            }
+            return "{} {}"_format(name, surname);
+        };
+    };
+    // AUI_DOCS_CODE_END
+    //
+    // In this expression, we have a fast path return if `name` is empty.
+    // AUI_DOCS_CODE_BEGIN
+    User u = {
+        .name = "Emma",
+        .surname = "Watson",
+    };
+    // trivial: we've accessed all referenced properties
+    EXPECT_EQ(u.fullName, "Emma Watson");
+    // AUI_DOCS_CODE_END
+
+    EXPECT_EQ(u.name.changed.mOutgoingConnections.size(), 1);
+    EXPECT_EQ(u.surname.changed.mOutgoingConnections.size(), 1);
+
+    // As soon as we set `name` to `""`, we don't access `surname`. If we try to trigger the fast path return:
+    // AUI_DOCS_CODE_BEGIN
+    u.name = "";
+    // AUI_DOCS_CODE_END
+    EXPECT_EQ(u.fullName, "-");
+    EXPECT_EQ(u.name.changed.mOutgoingConnections.size(), 1);
+    EXPECT_EQ(u.surname.changed.mOutgoingConnections.size(), 0);
+    // `surname` can't trigger re-evaluation anyhow. Re-evaluation can be triggered by `name` only. So, at the moment,
+    // we are interested in `name` changes only.
+    //
+    // `APropertyPrecomputed` might evaluate its expression several times during its lifetime. The developer must make
+    // sure that all objects referenced in the expression live longer than `APropertyPrecomputed`.
+    //
+    // The expression should not read from the property it's a binding for. Otherwise, there's an infinite evaluation
+    // loop.
+}
+

--- a/aui.core/tests/PropertyPrecomputed.cpp
+++ b/aui.core/tests/PropertyPrecomputed.cpp
@@ -86,9 +86,7 @@ TEST_F(PropertyPrecomputedTest, APropertyPrecomputed) {
     EXPECT_EQ(u->fullName, "Emma Stone");
 }
 
-TEST_F(PropertyPrecomputedTest, APropertyPrecomputed_Complex) {
-    //
-    // ### Valid Expressions
+TEST_F(PropertyPrecomputedTest, Valid_Expressions) { // HEADER_H1
     // Any C++ callable evaluating to `T` can be used as an expression for `APropertyPrecomputed<T>`. However, to
     // formulate correct expression, some rules must be satisfied.
     //

--- a/aui.core/tests/PropertyTest.cpp
+++ b/aui.core/tests/PropertyTest.cpp
@@ -7,190 +7,231 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-#include <AUI/Common/AObject.h>
-#include <AUI/Common/ASignal.h>
+#include <AUI/Common/AProperty.h>
+#include <AUI/Logging/ALogger.h>
 #include <AUI/Util/kAUI.h>
-#include <gtest/gtest.h>
 #include <gmock/gmock.h>
-#include "AUI/Common/AProperty.h"
+
+class PropertyTest: public testing::Test {
+public:
+    template<typename... Args>
+    static auto& connections(ASignal<Args...>& signal) {
+        return signal.mOutgoingConnections;
+    }
+
+    static auto& connections(AObject& object) {
+        return object.mIngoingConnections;
+    }
+};
 
 namespace {
+// AUI_DOCS_OUTPUT: doxygen/intermediate/property.h
+// @class AProperty
+// # Declaration
+// To declare a property inside your data model, use AProperty template:
+// AUI_DOCS_CODE_BEGIN
 struct User {
     AProperty<AString> name;
+    AProperty<AString> surname;
 };
+// AUI_DOCS_CODE_END
 
-
-class Receiver: public AObject {
+class LogObserver : public AObject {
 public:
-    MOCK_METHOD(void, receiveStr, (const AString& msg));
-    MOCK_METHOD(void, receiveInt, (int msg));
-};
-}
-
-TEST(PropertyTest, DesignatedInitializer) {
-    auto u = aui::ptr::manage(new User { .name = "Hello" });
-    EXPECT_EQ(u->name, "Hello");
-}
-
-TEST(PropertyTest, ValueCanBeChanged) {
-    auto u = aui::ptr::manage(new User { .name = "Hello" });
-    u->name = "World";
-
-    // this should not compile
-    // u->name = {"World"};
-
-    EXPECT_EQ(u->name, "World");
-}
-
-TEST(PropertyTest, ValueCanBePassed) {
-    auto u = aui::ptr::manage(new User { .name = "Hello" });
-    auto stringIdentity = [](const AString& value) {
-        return value;
-    };
-    EXPECT_EQ(stringIdentity(u->name), "Hello");
-}
-
-TEST(PropertyTest, ValueOperatorArrow) {
-    auto u = aui::ptr::manage(new User { .name = "Hello" });
-    EXPECT_EQ(u->name->length(), 5);
-}
-
-TEST(PropertyTest, ChangedSignal) {
-    auto u = aui::ptr::manage(new User { .name = "Hello" });
-    auto receiver = _new<Receiver>();
-    AObject::connect(u->name.changed, slot(receiver)::receiveStr);
-
-    EXPECT_CALL(*receiver, receiveStr(AString("World")));
-    u->name = "World";
-}
-
-TEST(PropertyTest, PropertyConnection) {
-    auto receiver = _new<Receiver>();
-    auto u = aui::ptr::manage(new User { .name = "Hello" });
-
-    EXPECT_CALL(*receiver, receiveStr(AString("Hello"))).Times(1);
-    AObject::connect(u->name, slot(receiver)::receiveStr);
-
-    EXPECT_CALL(*receiver, receiveStr(AString("World"))).Times(1);
-    u->name = "World";
-}
-
-TEST(PropertyTest, PropertyConnectionWithProjection1) {
-    auto receiver = _new<Receiver>();
-    auto u = aui::ptr::manage(new User { .name = "Hello" });
-
-    EXPECT_CALL(*receiver, receiveInt(5)).Times(1);
-    AObject::connect(u->name.readProjected(&AString::length), slot(receiver)::receiveInt);
-
-    EXPECT_CALL(*receiver, receiveInt(6)).Times(1);
-    u->name = "World!";
-}
-
-TEST(PropertyTest, PropertyConnectionWithProjection2) {
-    auto receiver = _new<Receiver>();
-    auto u = aui::ptr::manage(new User { .name = "Hello" });
-
-    EXPECT_CALL(*receiver, receiveInt(5)).Times(1);
-    AObject::connect(u->name.readProjected([](const AString& s) { return s.length(); }), slot(receiver)::receiveInt);
-
-    EXPECT_CALL(*receiver, receiveInt(6)).Times(1);
-    u->name = "World!";
-}
-
-namespace {
-class CustomSetter : public AObject {
-public:
-    CustomSetter() {
-        ON_CALL(*this, setName(testing::_)).WillByDefault([&](const AString& s) {
-            emit nameChanged(s);
+    LogObserver() {
+        ON_CALL(*this, log(testing::_)).WillByDefault([](const AString& msg) {
         });
     }
-
-    auto name() const {
-        return APropertyDef {
-            this,
-            &CustomSetter::getName,
-            &CustomSetter::setName,
-            nameChanged,
-        };
-    }
-
-    MOCK_METHOD(void, setName, (const AString& msg));
-
-private:
-    emits<AString> nameChanged;
-
-    AString getName() const { return "can't change"; }
+    MOCK_METHOD(void, log, (const AString& msg), ());
 };
 }
 
-TEST(PropertyTest, CustomSetter) {
-    CustomSetter u;
-    Receiver receiver;
+// `AProperty<T>` is a container holding an instance of `T`. You can assign a value to it with `operator=` and read
+// value with `value()` method or implicit conversion `operator T()`.
 
-    static_assert(AAnyProperty<decltype(u.name())>);
+TEST_F(PropertyTest, Declaration) {
+    //
+    // AProperty behaves like a class/struct data member:
+    {
+        // AUI_DOCS_CODE_BEGIN
+        User u;
+        u.name = "Hello";
+        EXPECT_EQ(u.name, "Hello");
+        // AUI_DOCS_CODE_END
+    }
 
-    EXPECT_CALL(u, setName(AString("World")));
-    EXPECT_CALL(receiver, receiveStr(AString("World")));
+    // You can even perform binary operations on it seamlessly:
+    {
+        // AUI_DOCS_CODE_BEGIN
+        User u;
+        u.name = "Hello";
+        u.name += " world!";
+        EXPECT_EQ(u.name, "Hello world!");
+        EXPECT_EQ(u.name->length(), AString("Hello world!").length());
+        // AUI_DOCS_CODE_END
+    }
 
-    AObject::connect(u.name().changed, slot(receiver)::receiveStr);
+    // In most cases, property is implicitly convertible to its underlying type:
+    {
+        // AUI_DOCS_CODE_BEGIN
+        auto doSomethingWithName = [](const AString& name) { EXPECT_EQ(name, "Hello"); };
+        User u;
+        u.name = "Hello";
+        doSomethingWithName(u.name);
+        // AUI_DOCS_CODE_END
 
-    u.name() = "World";
-    EXPECT_EQ(AString(u.name()), "can't change");
+
+        // If it doesn't, simply put an asterisk:
+        // AUI_DOCS_CODE_BEGIN
+        doSomethingWithName(*u.name);
+        //                 ^^^ HERE
+        // AUI_DOCS_CODE_END
+    }
+}
+TEST_F(PropertyTest, Observing_changes) { // HEADER_H1
+    // All property types offer `.changed` field which is a signal reporting value changes. Let's make little observer
+    // object for demonstration:
+    {
+        // AUI_DOCS_CODE_BEGIN
+        class LogObserver : public AObject {
+        public:
+            void log(const AString& msg) {
+                ALogger::info("LogObserver") << "Received value: " << msg;
+            }
+        };
+        // AUI_DOCS_CODE_END
+    }
+    {
+        //
+        // Example usage:
+        // AUI_DOCS_CODE_BEGIN
+        auto observer = _new<LogObserver>();
+        auto u = aui::ptr::manage(new User { .name = "Chloe" });
+        AObject::connect(u->name.changed, slot(observer)::log);
+        // AUI_DOCS_CODE_END
+        EXPECT_CALL(*observer, log(AString("Marinette")));
+        //
+        // At the moment, the program prints nothing. When we change the property:
+        // AUI_DOCS_CODE_BEGIN
+        u->name = "Marinette";
+        // AUI_DOCS_CODE_END
+        // Code produces the following output:
+        // @code
+        // [07:58:59][][LogObserver][INFO]: Received value: Marinette
+        // @endcode
+    }
+    {
+        testing::InSequence s;
+        //
+        // As you can see, observer received the update. But, for example, if we would like to display the value via
+        // label, the label wouldn't display the current value until the next update. We want the label to display
+        // *current* value without requiring an update. To do this, connect to the property directly, without explicitly
+        // asking for `changed`:
+        // AUI_DOCS_CODE_BEGIN
+        auto observer = _new<LogObserver>();
+        auto u = aui::ptr::manage(new User { .name = "Chloe" });
+
+        EXPECT_CALL(*observer, log(AString("Chloe"))).Times(1);
+        AObject::connect(u->name, slot(observer)::log);
+        // AUI_DOCS_CODE_END
+        // Code above produces the following output:
+        // @code
+        // [07:58:59][][LogObserver][INFO]: Received value: Chloe
+        // @endcode
+        // As you can see, observer receives the value without making updates to the value. The call of
+        // `LogObserver::log` is made by `AObject::connect` itself. In this document, we will call this behaviour as
+        // "pre-fire".
+        //
+        // Subsequent changes to field would send updates as well:
+        // AUI_DOCS_CODE_BEGIN
+        EXPECT_CALL(*observer, log(AString("Marinette"))).Times(1);
+        u->name = "Marinette";
+        // AUI_DOCS_CODE_END
+        // Assignment operation above makes an additional line to output:
+        // @code
+        // [07:58:59][][LogObserver][INFO]: Received value: Marinette
+        // @endcode
+        //
+        // Whole program output when connecting to property directly:
+        // @code
+        // [07:58:59][][LogObserver][INFO]: Received value: Chloe
+        // [07:58:59][][LogObserver][INFO]: Received value: Marinette
+        // @endcode
+    }
 }
 
-TEST(PropertyTest, CustomSetterProperty) {
-    CustomSetter u;
-    auto receiver = _new<Receiver>();
+TEST_F(PropertyTest, Copy_constructing_AProperty) { // HEADER_H1
+    {
+        User user { .name = "Hello" };
+        auto copy = user;
+        EXPECT_EQ(copy.name, "Hello");
+        EXPECT_EQ(copy.surname, "");
+    }
 
-    EXPECT_CALL(u, setName(AString("World")));
-    EXPECT_CALL(*receiver, receiveStr(AString("can't change"))).Times(1);
-    EXPECT_CALL(*receiver, receiveStr(AString("World"))).Times(1);
+    // Copying `AProperty` is considered as a valid operation as it's a data holder. However, it's worth to note
+    // that `AProperty` copies it's underlying data field only, the signal-slot relations are not borrowed.
+    {
+        // AUI_DOCS_CODE_BEGIN
+        auto observer = _new<LogObserver>();
+        auto original = aui::ptr::manage(new User { .name = "Chloe" });
 
-    AObject::connect(u.name(), slot(receiver)::receiveStr);
-
-    u.name() = "World";
-    EXPECT_EQ(AString(u.name()), "can't change");
+        EXPECT_CALL(*observer, log(AString("Chloe"))).Times(1);
+        AObject::connect(original->name, slot(observer)::log);
+        // AUI_DOCS_CODE_END
+        // This part is similar to previous examples, nothing new. Let's introduce a copy:
+        // AUI_DOCS_CODE_BEGIN
+        auto copy = _new<User>(*original);
+        EXPECT_EQ(copy->name, "Chloe"); // copied name
+        // AUI_DOCS_CODE_END
+        // Now, let's change `origin->name` and check that observer received an update, but value in the `copy`
+        // remains:
+        // AUI_DOCS_CODE_BEGIN
+        EXPECT_CALL(*observer, log(AString("Marinette"))).Times(1);
+        original->name = "Marinette";
+        EXPECT_EQ(copy->name, "Chloe"); // still
+        // AUI_DOCS_CODE_END
+        // In this example, observer is aware of changes `"Chloe"` -> `"Marinette"`. The copy is not aware because
+        // it is a **copy**. If we try to change the `copy`'s name:
+        // AUI_DOCS_CODE_BEGIN
+        copy->name = "Adrien";
+        // AUI_DOCS_CODE_END
+        // The observer is not aware about changes in `copy`. In fact. `copy->name` has zero connections.
+        EXPECT_EQ(connections(original->name.changed).size(), 1);
+        EXPECT_EQ(connections(copy->name.changed).size(), 0);
+        EXPECT_EQ(connections(*observer).size(), 1);
+    }
 }
 
-TEST(PropertyTest, Property2PropertyBoth) {
-    auto u = aui::ptr::manage(new User { .name = "initial" });
-    auto r = _new<CustomSetter>();
+TEST_F(PropertyTest, Copy_assigning_AProperty) { // HEADER_H1
+    {
+        User user1{ .name = "Hello" };
+        EXPECT_EQ(user1.name, "Hello");
+        User user2;
+        EXPECT_EQ(user2.name, "");
+        user2 = user1;
+        EXPECT_EQ(user2.name, "Hello");
+    }
+    // The situation with copy assigning `auto copy = _new<User>(); *copy = *original;` is similar to copy
+    // construction `auto copy = _new<User>(*original);`, except that we are copying to some pre-existing
+    // data structure that potentially have signal-slot relations already. So, not only connections should be kept
+    // as is but a notification for copy destination's observers is needed.
+    //
+    // As with copy construction, copy operation of `AProperty` does not affect signal-slot relations. Moreover,
+    // it notifies the observers.
+    // AUI_DOCS_CODE_BEGIN
+    auto observer = _new<LogObserver>();
+    auto original = aui::ptr::manage(new User { .name = "Chloe" });
 
-    EXPECT_CALL(*r, setName(AString("initial"))).Times(1);
-    AObject::biConnect(u->name, r->name());
-
-    EXPECT_CALL(*r, setName(AString("New Name1"))).Times(1);
-    u->name = "New Name1";
-
-    EXPECT_CALL(*r, setName(AString("New Name2"))).Times(2); // expected to call 2 times: 1st time by calling setName
-    r->setName("New Name2");                                 // here; 2nd time as a loopback response from u
-
-    // the setName "New Name2" call above should reflect its change to u.
-    EXPECT_EQ(u->name, "New Name2");
-
-    // death of r should clear the link with u->name.
-    r = nullptr;
-    u->name = "Should not crash";
-}
-
-TEST(PropertyTest, Property2PropertySetOnly) {
-    auto u = aui::ptr::manage(new User { .name = "initial" });
-    auto r = _new<CustomSetter>();
-
-    EXPECT_CALL(*r, setName(AString("initial"))).Times(1);
-    AObject::connect(u->name, r->name());
-
-    EXPECT_CALL(*r, setName(AString("New Name1"))).Times(1);
-    u->name = "New Name1";
-
-    EXPECT_CALL(*r, setName(AString("New Name2"))).Times(1);
-    r->setName("New Name2");
-
-    // the setName "New Name2" call above should NOT reflect its change to u.
-    EXPECT_EQ(u->name, "New Name1");
-
-    // death of r should clear the link with u->name.
-    r = nullptr;
-    u->name = "Should not crash";
+    EXPECT_CALL(*observer, log(AString("Chloe"))).Times(1);
+    AObject::connect(original->name, slot(observer)::log);
+    // AUI_DOCS_CODE_END
+    // This part is similar to previous examples, nothing new. Let's perform copy-assignment:
+    // AUI_DOCS_CODE_BEGIN
+    EXPECT_CALL(*observer, log(AString("Marinette"))).Times(1);
+    User copy { .name = "Marinette" };
+    *original = copy;
+    // AUI_DOCS_CODE_END
+    // See, not only the connection remains, but it also receives notification about the change.
+    EXPECT_EQ(connections(original->name.changed).size(), 1);
+    EXPECT_EQ(connections(*observer).size(), 1);
 }

--- a/aui.json/src/AUI/Json/Conversion.h
+++ b/aui.json/src/AUI/Json/Conversion.h
@@ -379,3 +379,13 @@ struct AJsonConv<T, typename std::enable_if_t<std::is_enum_v<T>>> {
     }
 };
 
+
+template<APropertyWritable T>
+struct AJsonConv<T> {
+    static AJson toJson(const T& t) {
+        return t.value();
+    }
+    static void fromJson(const AJson& json, T& dst) {
+        dst = aui::from_json<typename T::Underlying>(json);
+    }
+};

--- a/aui.json/tests/JsonFieldsTest.cpp
+++ b/aui.json/tests/JsonFieldsTest.cpp
@@ -19,6 +19,7 @@
 #include <AUI/Json/AJson.h>
 #include <AUI/Traits/parameter_pack.h>
 #include <AUI/Traits/members.h>
+#include "AUI/Common/AProperty.h"
 
 // ORM data class
 struct Data2 {
@@ -83,4 +84,29 @@ TEST(Json, FieldsTestOptional)
 
     // here it should throw an exception since v1 is not optional
     EXPECT_THROW(aui::from_json<DataOptional>(AJson::fromString(R"({"v2":228})")), AJsonException);
+}
+
+struct DataProperty {
+    AProperty<int> v1;
+    AProperty<AString> v2;
+};
+
+AJSON_FIELDS(DataProperty,
+             (v1, "v1")
+             (v2, "v2"))
+
+TEST(Json, DataProperty)
+{
+    DataProperty property {
+        .v1 = 111,
+        .v2 = "string",
+    };
+
+    auto str = AJson::toString(aui::to_json(property));
+    EXPECT_EQ(str, R"({"v1":111,"v2":"string"})");
+
+    // and back
+    auto parsed = aui::from_json<DataProperty>(AJson::fromString(str));
+    EXPECT_EQ(parsed.v1, property.v1);
+    EXPECT_EQ(parsed.v2, property.v2);
 }

--- a/aui.uitests/tests/UIDataBindingTest.cpp
+++ b/aui.uitests/tests/UIDataBindingTest.cpp
@@ -142,7 +142,7 @@ TEST_F(UIDataBindingTest, TextField1) {
 // This approach allows more control over the binding process by using `AObject::connect`/`AObject::biConnect` which is
 // a procedural way of setting up connections. As a downside, it requires "let" syntax clause which may seem as overkill
 // for such a simple operation.
-TEST_F(UIDataBindingTest, Label_via_let) { // HEADER
+TEST_F(UIDataBindingTest, Label_via_let) { // HEADER_H2
     // Use \c let expression to connect the model's username property to the label's @ref ALabel::text "text()"
     // property.
     // AUI_DOCS_CODE_BEGIN
@@ -204,7 +204,7 @@ TEST_F(UIDataBindingTest, Label_via_let) { // HEADER
     EXPECT_EQ(label->text(), "World");
 }
 
-TEST_F(UIDataBindingTest, Label_via_let_projection) { // HEADER
+TEST_F(UIDataBindingTest, Label_via_let_projection) { // HEADER_H2
     // It's fairly easy to define a projection because one-sided connection requires exactly one projection, obviously.
     using namespace declarative;
 
@@ -261,7 +261,7 @@ TEST_F(UIDataBindingTest, Label_via_let_projection) { // HEADER
     EXPECT_EQ(label->text(), "VASIL"); // uppercased by projection!
 }
 
-TEST_F(UIDataBindingTest, Bidirectional_connection) { // HEADER
+TEST_F(UIDataBindingTest, Bidirectional_connection) { // HEADER_H2
     // In previous examples, we've used `AObject::connect` to make one directional (one sided) connection. This is
     // perfectly enough for ALabel because it cannot be changed by user.
     //
@@ -341,7 +341,7 @@ AUI_ENUM_VALUES(Gender,
                 Gender::FEMALE,
                 Gender::OTHER)
 
-TEST_F(UIDataBindingTest, Bidirectional_projection) { // HEADER
+TEST_F(UIDataBindingTest, Bidirectional_projection) { // HEADER_H2
     using namespace declarative;
     // Bidirectional connection updates values in both directions, hence it requires the projection to work in both
     // sides as well.
@@ -488,7 +488,7 @@ TEST_F(UIDataBindingTest, Bidirectional_projection) { // HEADER
 // Also, `>` operator (resembles arrow) is used to specify the destination slot.
 //
 // The example below is essentially the same as @ref "UIDataBindingTest_Label_via_let" but uses declarative connection set up syntax.
-TEST_F(UIDataBindingTest, Label_via_declarative) { // HEADER
+TEST_F(UIDataBindingTest, Label_via_declarative) { // HEADER_H2
     // Use `&` and `>` expression to connect the model's username property to the label's @ref ALabel::text "text"
     // property.
     // AUI_DOCS_CODE_BEGIN
@@ -545,7 +545,7 @@ TEST_F(UIDataBindingTest, Label_via_declarative) { // HEADER
     }
 }
 
-TEST_F(UIDataBindingTest, ADataBindingDefault_for_omitting_view_property) { // HEADER
+TEST_F(UIDataBindingTest, ADataBindingDefault_for_omitting_view_property) { // HEADER_H2
     // In previous example we have explicitly specified ALabel's property to connect with.
     //
     // One of notable features of declarative way (in comparison to procedural `let` way) is that we can omit the view's
@@ -616,7 +616,7 @@ TEST_F(UIDataBindingTest, ADataBindingDefault_for_omitting_view_property) { // H
     }
 }
 
-TEST_F(UIDataBindingTest, ADataBindingDefault_strong_type_propagation) { // HEADER
+TEST_F(UIDataBindingTest, ADataBindingDefault_strong_type_propagation) { // HEADER_H2
     using namespace declarative;
     // Think of `ADataBindingDefault` as we're not only connecting properties to properties, but also creating a
     // "property to view" relationship. This philosophy covers the following scenario.
@@ -685,7 +685,7 @@ TEST_F(UIDataBindingTest, ADataBindingDefault_strong_type_propagation) { // HEAD
     // propagates its constraints on `ANumberPicker` thanks to `ADataBindingDefault` specialization.
 }
 
-TEST_F(UIDataBindingTest, Label_via_declarative_projection) { // HEADER
+TEST_F(UIDataBindingTest, Label_via_declarative_projection) { // HEADER_H2
     // We can use projections in the same way as with `let`.
     // AUI_DOCS_CODE_BEGIN
     using namespace declarative;
@@ -814,7 +814,7 @@ TEST_F(UIDataBindingTest, Declarative_custom_slot3) {
     EXPECT_EQ(label->visibility(), Visibility::INVISIBLE);
 }
 
-TEST_F(UIDataBindingTest, Declarative_bidirectional_connection) { // HEADER
+TEST_F(UIDataBindingTest, Declarative_bidirectional_connection) { // HEADER_H2
     // In previous examples, we've used `&` to make one directional (one sided) connection. This is
     // perfectly enough for ALabel because it cannot be changed by user.
     //
@@ -879,7 +879,7 @@ TEST_F(UIDataBindingTest, Declarative_bidirectional_connection) { // HEADER
     // changes.
 }
 
-TEST_F(UIDataBindingTest, Declarative_bidirectional_projection) { // HEADER
+TEST_F(UIDataBindingTest, Declarative_bidirectional_projection) { // HEADER_H2
     // We can use projections in the same way as with `let`.
     //
     // Let's repeat the @ref "UIDataBindingTest_Bidirectional_projection" sample in declarative way:

--- a/aui.uitests/tests/UIDataBindingTest.cpp
+++ b/aui.uitests/tests/UIDataBindingTest.cpp
@@ -180,7 +180,7 @@ TEST_F(UIDataBindingTest, Label_via_let) { // HEADER_H2
     // AUI_DOCS_CODE_END
     //
     // This gives the following result:
-    // ![text](imgs/UIDataBindingTest.Label_via_declarative_1.png)
+    // ![](imgs/UIDataBindingTest.Label_via_declarative_1.png)
     // Note that label already displays the value stored in User.
 
     auto label = _cast<ALabel>(By::type<ALabel>().one());
@@ -195,10 +195,9 @@ TEST_F(UIDataBindingTest, Label_via_let) { // HEADER_H2
     // AUI_DOCS_CODE_END
     EXPECT_EQ(user->name, "Vasil");
     EXPECT_EQ(label->text(), "Vasil");
-    // ![text](imgs/UIDataBindingTest.Label_via_declarative_2.png)
+    // ![](imgs/UIDataBindingTest.Label_via_declarative_2.png)
     //
-    // By simply performing assignment on `user` we changed ALabel display text.
-    // Magic, huh?
+    // By simply performing assignment on `user` we changed ALabel display text. Magic, huh?
 
     user->name = "World";
     EXPECT_EQ(label->text(), "World");
@@ -242,7 +241,7 @@ TEST_F(UIDataBindingTest, Label_via_let_projection) { // HEADER_H2
 
     //
     // This gives the following result:
-    // ![text](imgs/UIDataBindingTest.Label_via_declarative_projection_1.png)
+    // ![](imgs/UIDataBindingTest.Label_via_declarative_projection_1.png)
     // Note that the label already displays the **projected** value stored in User.
 
     auto label = _cast<ALabel>(By::type<ALabel>().one());
@@ -253,7 +252,7 @@ TEST_F(UIDataBindingTest, Label_via_let_projection) { // HEADER_H2
     user->name = "Vasil";
     // AUI_DOCS_CODE_END
 
-    // ![text](imgs/UIDataBindingTest.Label_via_declarative_projection_2.png)
+    // ![](imgs/UIDataBindingTest.Label_via_declarative_projection_2.png)
     //
     // This way, we've set up data binding with projection.
 
@@ -302,7 +301,7 @@ TEST_F(UIDataBindingTest, Bidirectional_connection) { // HEADER_H2
     _new<MyWindow>(user)->show();
     //
     // This gives the following result:
-    // ![text](imgs/UIDataBindingTest.Declarative_bidirectional_connection_1.png)
+    // ![](imgs/UIDataBindingTest.Declarative_bidirectional_connection_1.png)
 
     auto tf = _cast<ATextField>(By::type<ATextField>().one());
 
@@ -313,7 +312,7 @@ TEST_F(UIDataBindingTest, Bidirectional_connection) { // HEADER_H2
     // AUI_DOCS_CODE_END
     //
     // ATextField will respond:
-    // ![text](imgs/UIDataBindingTest.Declarative_bidirectional_connection_2.png)
+    // ![](imgs/UIDataBindingTest.Declarative_bidirectional_connection_2.png)
 
     EXPECT_EQ(user->name, "Vasil");
     EXPECT_EQ(tf->text(), "Vasil");
@@ -322,7 +321,7 @@ TEST_F(UIDataBindingTest, Bidirectional_connection) { // HEADER_H2
     // If the user changes the value from UI, these changes will reflect on `user->model` as well:
     tf->selectAll();
     By::value(tf).perform(type("Changed from UI"));
-    // ![text](imgs/UIDataBindingTest.Declarative_bidirectional_connection_3.png)
+    // ![](imgs/UIDataBindingTest.Declarative_bidirectional_connection_3.png)
     // AUI_DOCS_CODE_BEGIN
     EXPECT_EQ(user->name, "Changed from UI");
     // AUI_DOCS_CODE_END
@@ -453,7 +452,7 @@ TEST_F(UIDataBindingTest, Bidirectional_projection) { // HEADER_H2
     _new<MyWindow>(user)->show();
     // AUI_DOCS_CODE_END
     auto dropdownList = _cast<ADropdownList>(By::type<ADropdownList>().one());
-    // ![dropdownlist](imgs/UIDataBindingTest.Declarative_bidirectional_projection_1.png)
+    //![](imgs/UIDataBindingTest.Declarative_bidirectional_projection_1.png)
 
     //
     // - If we try to change `user->gender` programmatically, ADropdownList will respond:
@@ -461,7 +460,7 @@ TEST_F(UIDataBindingTest, Bidirectional_projection) { // HEADER_H2
     user->gender = Gender::FEMALE;
     EXPECT_EQ(dropdownList->getSelectedId(), 1); // second option
     // AUI_DOCS_CODE_END
-    // ![dropdownlist](imgs/UIDataBindingTest.Declarative_bidirectional_projection_2.png)
+    //![](imgs/UIDataBindingTest.Declarative_bidirectional_projection_2.png)
 
     //
     // - If the user changes the value of ADropdownList, it reflects on the model as well:
@@ -469,7 +468,7 @@ TEST_F(UIDataBindingTest, Bidirectional_projection) { // HEADER_H2
     // AUI_DOCS_CODE_BEGIN
     EXPECT_EQ(user->gender, Gender::OTHER);
     // AUI_DOCS_CODE_END
-    // ![dropdownlist](imgs/UIDataBindingTest.Declarative_bidirectional_projection_3.png)
+    //![](imgs/UIDataBindingTest.Declarative_bidirectional_projection_3.png)
 }
 
 //
@@ -518,7 +517,7 @@ TEST_F(UIDataBindingTest, Label_via_declarative) { // HEADER_H2
     EXPECT_EQ(label->text(), "Roza");
 
     saveScreenshot("1");
-    // ![text](imgs/UIDataBindingTest.Label_via_declarative_1.png)
+    // ![](imgs/UIDataBindingTest.Label_via_declarative_1.png)
 
     // Note that the label already displays the value stored in User.
     //
@@ -530,7 +529,7 @@ TEST_F(UIDataBindingTest, Label_via_declarative) { // HEADER_H2
     EXPECT_EQ(user->name, "Vasil");
     EXPECT_EQ(label->text(), "Vasil");
     saveScreenshot("2");
-    // ![text](imgs/UIDataBindingTest.Label_via_declarative_2.png)
+    // ![](imgs/UIDataBindingTest.Label_via_declarative_2.png)
 
     user->name = "World";
     EXPECT_EQ(label->text(), "World");
@@ -591,7 +590,7 @@ TEST_F(UIDataBindingTest, ADataBindingDefault_for_omitting_view_property) { // H
     //
     // Behaviour of such connection is equal to @ref "UIDataBindingTest_Label_via_declarative":
     //
-    // ![text](imgs/UIDataBindingTest.Label_via_declarative_1.png)
+    // ![](imgs/UIDataBindingTest.Label_via_declarative_1.png)
 
     // Note that the label already displays the value stored in User.
     //
@@ -602,7 +601,7 @@ TEST_F(UIDataBindingTest, ADataBindingDefault_for_omitting_view_property) { // H
 
     EXPECT_EQ(user->name, "Vasil");
     EXPECT_EQ(label->text(), "Vasil");
-    // ![text](imgs/UIDataBindingTest.Label_via_declarative_2.png)
+    // ![](imgs/UIDataBindingTest.Label_via_declarative_2.png)
 
     user->name = "World";
     EXPECT_EQ(label->text(), "World");
@@ -710,7 +709,7 @@ TEST_F(UIDataBindingTest, Label_via_declarative_projection) { // HEADER_H2
     window->setScalingParams({ .scalingFactor = 2.f });
     auto label = _cast<ALabel>(By::type<ALabel>().one());
     saveScreenshot("1");
-    // ![text](imgs/UIDataBindingTest.Label_via_declarative_projection_1.png)
+    // ![](imgs/UIDataBindingTest.Label_via_declarative_projection_1.png)
     //
     // Note that the label already displays the **projected** value stored in User.
     //
@@ -722,7 +721,7 @@ TEST_F(UIDataBindingTest, Label_via_declarative_projection) { // HEADER_H2
     EXPECT_EQ(label->text(), "VASIL"); // projected
     // AUI_DOCS_CODE_END
     saveScreenshot("2");
-    // ![text](imgs/UIDataBindingTest.Label_via_declarative_projection_2.png)
+    // ![](imgs/UIDataBindingTest.Label_via_declarative_projection_2.png)
 
     user->name = "World";
     EXPECT_EQ(label->text(), "WORLD");
@@ -848,7 +847,7 @@ TEST_F(UIDataBindingTest, Declarative_bidirectional_connection) { // HEADER_H2
     //
     // This gives the following result:
     saveScreenshot("1");
-    // ![text](imgs/UIDataBindingTest.Declarative_bidirectional_connection_1.png)
+    // ![](imgs/UIDataBindingTest.Declarative_bidirectional_connection_1.png)
 
     auto tf = _cast<ATextField>(By::type<ATextField>().one());
 
@@ -860,7 +859,7 @@ TEST_F(UIDataBindingTest, Declarative_bidirectional_connection) { // HEADER_H2
     //
     // ATextField will respond:
     saveScreenshot("2");
-    // ![text](imgs/UIDataBindingTest.Declarative_bidirectional_connection_2.png)
+    // ![](imgs/UIDataBindingTest.Declarative_bidirectional_connection_2.png)
 
     EXPECT_EQ(user->name, "Vasil");
     EXPECT_EQ(tf->text(), "Vasil");
@@ -870,7 +869,7 @@ TEST_F(UIDataBindingTest, Declarative_bidirectional_connection) { // HEADER_H2
     tf->selectAll();
     By::value(tf).perform(type("Changed from UI"));
     saveScreenshot("3");
-    // ![text](imgs/UIDataBindingTest.Declarative_bidirectional_connection_3.png)
+    // ![](imgs/UIDataBindingTest.Declarative_bidirectional_connection_3.png)
     // AUI_DOCS_CODE_BEGIN
     EXPECT_EQ(user->name, "Changed from UI");
     // AUI_DOCS_CODE_END
@@ -907,7 +906,7 @@ TEST_F(UIDataBindingTest, Declarative_bidirectional_projection) { // HEADER_H2
                 // AUI_DOCS_CODE_BEGIN
                 _new<ADropdownList>(gendersStr) && user->gender.biProjected(GENDER_INDEX_PROJECTION) > &ADropdownList::selectionId
                 // AUI_DOCS_CODE_END
-                // ![dropdownlist](imgs/UIDataBindingTest.Declarative_bidirectional_projection_1.png)
+                //![](imgs/UIDataBindingTest.Declarative_bidirectional_projection_1.png)
                 // @note
                 // We used the `&&` operator here instead of `&` because we want the connection work in both
                 // directions: `user.gender -> ADropdownList` and `ADropdownList -> user.gender`.
@@ -928,7 +927,7 @@ TEST_F(UIDataBindingTest, Declarative_bidirectional_projection) { // HEADER_H2
     EXPECT_EQ(dropdownList->getSelectedId(), 1); // second option
     // AUI_DOCS_CODE_END
     saveScreenshot("2");
-    // ![dropdownlist](imgs/UIDataBindingTest.Declarative_bidirectional_projection_2.png)
+    //![](imgs/UIDataBindingTest.Declarative_bidirectional_projection_2.png)
 
     //
     // - If the user changes the value of ADropdownList, it reflects on the model as well:
@@ -937,7 +936,7 @@ TEST_F(UIDataBindingTest, Declarative_bidirectional_projection) { // HEADER_H2
     // AUI_DOCS_CODE_BEGIN
     EXPECT_EQ(user->gender, Gender::OTHER);
     // AUI_DOCS_CODE_END
-    // ![dropdownlist](imgs/UIDataBindingTest.Declarative_bidirectional_projection_3.png)
+    //![](imgs/UIDataBindingTest.Declarative_bidirectional_projection_3.png)
 }
 
 //

--- a/doxygen/DoxygenLayout.xml
+++ b/doxygen/DoxygenLayout.xml
@@ -97,9 +97,9 @@
             <events title=""/>
         </memberdef>
         <allmemberslink visible="yes"/>
-        <usedfiles visible="$SHOW_USED_FILES"/>
-        <inheritancegraph visible="$CLASS_GRAPH"/>
-        <collaborationgraph visible="$COLLABORATION_GRAPH"/>
+<!--        <usedfiles visible="$SHOW_USED_FILES"/>-->
+<!--        <inheritancegraph visible="$CLASS_GRAPH"/>-->
+<!--        <collaborationgraph visible="$COLLABORATION_GRAPH"/>-->
         <authorsection visible="yes"/>
     </class>
 

--- a/doxygen/DoxygenLayout.xml
+++ b/doxygen/DoxygenLayout.xml
@@ -213,7 +213,7 @@
             <properties title=""/>
             <friends title=""/>
         </memberdef>
-        <groupgraph visible="$GROUP_GRAPHS"/>
+<!--        <groupgraph visible="$GROUP_GRAPHS"/>-->
         <authorsection visible="yes"/>
     </group>
 

--- a/doxygen/docs.py
+++ b/doxygen/docs.py
@@ -40,9 +40,9 @@ REGEX_AUI_DOCS_OUTPUT = re.compile(r'^// ?AUI_DOCS_OUTPUT: ?(.+)\n$')
 REGEX_COMMENT = re.compile(r'\s*// ?(.*)\n?$')
 assert REGEX_COMMENT.match("   // AUI_DOCS_CODE_BEGIN\n")
 
-# TEST_F(UIDataBindingTest, AProperty) { // HEADER
-REGEX_TESTCASE_HEADER = re.compile(r'TEST_F\((.+), (.+)\) ?\{ ?// ?HEADER')
+# TEST_F(UIDataBindingTest, AProperty) { // HEADER_H2
 REGEX_TESTCASE_HEADER_H1 = re.compile(r'TEST_F\((.+), (.+)\) ?\{ ?// ?HEADER_H1')
+REGEX_TESTCASE_HEADER_H2 = re.compile(r'TEST_F\((.+), (.+)\) ?\{ ?// ?HEADER_H2')
 
 REGEX_INGROUP = re.compile(r'.*([@\\]ingroup ?\w*).*')
 assert REGEX_INGROUP.match("   * @ingroup")
@@ -140,7 +140,7 @@ def process_cpp_file(input: Path):
                     emit_line()
                     continue
 
-                if match := REGEX_TESTCASE_HEADER.match(line):
+                if match := REGEX_TESTCASE_HEADER_H2.match(line):
                     emit_line()
                     fos.write("## ")
                     fos.write(match.group(2).replace("_", " "))

--- a/doxygen/docs.py
+++ b/doxygen/docs.py
@@ -41,7 +41,8 @@ REGEX_COMMENT = re.compile(r'\s*// ?(.*)\n?$')
 assert REGEX_COMMENT.match("   // AUI_DOCS_CODE_BEGIN\n")
 
 # TEST_F(UIDataBindingTest, AProperty) { // HEADER
-REGEX_TESTCASE_HEADER = re.compile(r'TEST_F\(.+, (.+)\) ?\{ ?// ?HEADER')
+REGEX_TESTCASE_HEADER = re.compile(r'TEST_F\((.+), (.+)\) ?\{ ?// ?HEADER')
+REGEX_TESTCASE_HEADER_H1 = re.compile(r'TEST_F\((.+), (.+)\) ?\{ ?// ?HEADER_H1')
 
 REGEX_INGROUP = re.compile(r'.*([@\\]ingroup ?\w*).*')
 assert REGEX_INGROUP.match("   * @ingroup")
@@ -129,12 +130,22 @@ def process_cpp_file(input: Path):
                 CODE_END = "@endcode"
 
             for line in lines:
+                if match := REGEX_TESTCASE_HEADER_H1.match(line):
+                    emit_line()
+                    fos.write("# ")
+                    fos.write(match.group(2).replace("_", " "))
+                    fos.write(" {#")
+                    fos.write(f'{match.group(1)}_{match.group(2)}')
+                    fos.write("}")
+                    emit_line()
+                    continue
+
                 if match := REGEX_TESTCASE_HEADER.match(line):
                     emit_line()
                     fos.write("## ")
-                    fos.write(match.group(1).replace("_", " "))
+                    fos.write(match.group(2).replace("_", " "))
                     fos.write(" {#")
-                    fos.write(match.group(1))
+                    fos.write(f'{match.group(1)}_{match.group(2)}')
                     fos.write("}")
                     emit_line()
                     continue


### PR DESCRIPTION
Inspired by this [comment](https://github.com/aui-framework/aui/issues/81#issuecomment-2591711311) (#81), several fixes to the new property system.

- JSON interop
- copy/move construction/assignment operations

Also I've played around Doxygen a little bit. The page about property system was somewhat bloated with implementation details.`UIDataBindingTest.cpp` which hosts the entire documentation page with unit tests reached 1500+ lines of code. So I moved the specifics of `AProperty`, `APropertyDef` and `APropertyPrecomputed` to their respective doc pages, as well as the underlying `cpp` test file was split in several `cpp` files.