### PR TITLE
AProperty modifier concept

### DIFF
--- a/aui.core/src/AUI/Common/AProperty.h
+++ b/aui.core/src/AUI/Common/AProperty.h
@@ -242,7 +242,7 @@ struct AProperty: AObjectBase {
     /**
      * @return @copybrief aui::PropertyModifier See aui::PropertyModifier.
      */
-    aui::PropertyModifier<AProperty> modify() noexcept {
+    aui::PropertyModifier<AProperty> writeScope() noexcept {
         return { *this };
     }
 
@@ -421,7 +421,7 @@ struct APropertyDef {
     /**
      * @return @copybrief aui::PropertyModifier See aui::PropertyModifier.
      */
-    aui::PropertyModifier<APropertyDef> modify() noexcept {
+    aui::PropertyModifier<APropertyDef> writeScope() noexcept {
         return { *this };
     }
 
@@ -446,6 +446,7 @@ private:
 };
 
 // binary operations for properties.
+// note: sync this PropertyModifier.h
 template<AAnyProperty Lhs, typename Rhs>
 [[nodiscard]]
 inline auto operator==(const Lhs& lhs, Rhs&& rhs) {
@@ -476,7 +477,7 @@ inline decltype(auto) operator+=(Lhs& lhs, Rhs&& rhs)  {
         // const operator?
         return *lhs += std::forward<Rhs>(rhs);
     } else {
-        return *lhs.modify() += std::forward<Rhs>(rhs);
+        return *lhs.writeScope() += std::forward<Rhs>(rhs);
     }
 }
 

--- a/aui.core/src/AUI/Common/AString.h
+++ b/aui.core/src/AUI/Common/AString.h
@@ -11,6 +11,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <string>
 #include <iostream>
 #include "AUI/Core.h"
@@ -703,7 +704,7 @@ public:
     AString processEscapes() const;
 
     AString& removeAll(char16_t c) noexcept {
-        erase(std::remove(begin(), end(), c));
+        erase(std::remove(begin(), end(), c), end());
         return *this;
     }
 

--- a/aui.core/src/AUI/Common/PropertyModifier.h
+++ b/aui.core/src/AUI/Common/PropertyModifier.h
@@ -1,0 +1,59 @@
+// AUI Framework - Declarative UI toolkit for modern C++20
+// Copyright (C) 2020-2024 Alex2772 and Contributors
+//
+// SPDX-License-Identifier: MPL-2.0
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+#include <AUI/Traits/concepts.h>
+
+namespace aui {
+/**
+ * @brief Temporary transparent object that gains write access to underlying property's value, notifying about value
+ * changes when destructed.
+ * @ingroup property_system
+ * @details
+ * PropertyModifier is a result of `modify()` method of writeable properties. It gains tranparent writeable handle to
+ * property's value, and calls `notify()` methos on property upon PropertyModifier destructor.
+ *
+ * This ensures that a write access to the property is committed and can be observed.
+ */
+template<typename Property>
+class PropertyModifier {
+public:
+    using Underlying = typename Property::Underlying;
+    PropertyModifier(Property& owner): mOwner(&owner) {}
+    ~PropertyModifier() {
+        if (mOwner == nullptr) {
+            return;
+        }
+        mOwner->notify();
+    }
+
+    [[nodiscard]]
+    const Underlying& value() const noexcept {
+        return mOwner->value();
+    }
+
+    [[nodiscard]]
+    Underlying& value() noexcept {
+        return const_cast<Underlying&>(mOwner->value());
+    }
+
+private:
+    Property* mOwner;
+};
+}
+
+template<typename T>
+inline decltype(auto) operator*(aui::PropertyModifier<T>& t) {
+    return t.value();
+}
+
+template<typename T>
+inline decltype(auto) operator*(const aui::PropertyModifier<T>& t) {
+    return t.value();
+}
+

--- a/aui.core/src/AUI/Common/PropertyModifier.h
+++ b/aui.core/src/AUI/Common/PropertyModifier.h
@@ -15,46 +15,13 @@ namespace aui {
  * changes when destructed.
  * @ingroup property_system
  * @details
- * PropertyModifier is a result of `writeScope()` method of writeable properties. It gains tranparent writeable handle
- * to property's value, and calls `notify()` methos on property upon PropertyModifier destructor.
+ * PropertyModifier is a result of `writeScope()` method of writeable properties. Also, it is used inside non-const
+ * operator implementations (see below). It gains transparent writeable handle to property's value, and calls `notify()`
+ * method on associated property upon PropertyModifier destruction.
  *
- * This ensures that a write access to the property is committed and can be observed.
  */
 template<typename Property>
-class PropertyModifier {
-public:
-    using Underlying = typename Property::Underlying;
-    PropertyModifier(Property& owner): mOwner(&owner) {}
-    ~PropertyModifier() {
-        if (mOwner == nullptr) {
-            return;
-        }
-        mOwner->notify();
-    }
-
-    [[nodiscard]]
-    const Underlying& value() const noexcept {
-        return mOwner->value();
-    }
-
-    [[nodiscard]]
-    Underlying& value() noexcept {
-        return const_cast<Underlying&>(mOwner->value());
-    }
-
-    [[nodiscard]]
-    const Underlying* operator->() const noexcept {
-        return &value();
-    }
-
-    [[nodiscard]]
-    Underlying* operator->() noexcept {
-        return &value();
-    }
-
-private:
-    Property* mOwner;
-};
+class PropertyModifier;
 }
 
 template<typename T>

--- a/aui.core/src/AUI/Common/PropertyModifier.h
+++ b/aui.core/src/AUI/Common/PropertyModifier.h
@@ -15,8 +15,8 @@ namespace aui {
  * changes when destructed.
  * @ingroup property_system
  * @details
- * PropertyModifier is a result of `modify()` method of writeable properties. It gains tranparent writeable handle to
- * property's value, and calls `notify()` methos on property upon PropertyModifier destructor.
+ * PropertyModifier is a result of `writeScope()` method of writeable properties. It gains tranparent writeable handle
+ * to property's value, and calls `notify()` methos on property upon PropertyModifier destructor.
  *
  * This ensures that a write access to the property is committed and can be observed.
  */
@@ -42,13 +42,23 @@ public:
         return const_cast<Underlying&>(mOwner->value());
     }
 
+    [[nodiscard]]
+    const Underlying* operator->() const noexcept {
+        return &value();
+    }
+
+    [[nodiscard]]
+    Underlying* operator->() noexcept {
+        return &value();
+    }
+
 private:
     Property* mOwner;
 };
 }
 
 template<typename T>
-inline decltype(auto) operator*(aui::PropertyModifier<T>& t) {
+inline decltype(auto) operator*(aui::PropertyModifier<T>&& t) {
     return t.value();
 }
 
@@ -57,3 +67,38 @@ inline decltype(auto) operator*(const aui::PropertyModifier<T>& t) {
     return t.value();
 }
 
+template<typename T, typename Rhs>
+[[nodiscard]]
+inline auto operator==(const aui::PropertyModifier<T>& lhs, Rhs&& rhs) {
+    return *lhs == std::forward<Rhs>(rhs);
+}
+
+template<typename T, typename Rhs>
+[[nodiscard]]
+inline auto operator!=(const aui::PropertyModifier<T>& lhs, Rhs&& rhs) {
+    return *lhs != std::forward<Rhs>(rhs);
+}
+
+template<AAnyProperty T, typename Rhs>
+[[nodiscard]]
+inline auto operator+(const aui::PropertyModifier<T>& lhs, Rhs&& rhs) {
+    return *lhs + std::forward<Rhs>(rhs);
+}
+
+template<AAnyProperty T, typename Rhs>
+[[nodiscard]]
+inline auto operator-(const aui::PropertyModifier<T>& lhs, Rhs&& rhs) {
+    return *lhs - std::forward<Rhs>(rhs);
+}
+
+template<AAnyProperty T, typename Rhs>
+[[nodiscard]]
+inline auto operator+=(aui::PropertyModifier<T>& lhs, Rhs&& rhs) {
+    return *lhs += std::forward<Rhs>(rhs);
+}
+
+template<AAnyProperty T, typename Rhs>
+[[nodiscard]]
+inline auto operator-=(aui::PropertyModifier<T>& lhs, Rhs&& rhs) {
+    return *lhs -= std::forward<Rhs>(rhs);
+}

--- a/aui.core/src/AUI/Traits/concepts.h
+++ b/aui.core/src/AUI/Traits/concepts.h
@@ -216,6 +216,8 @@ template <typename T>
 concept APropertyWritable = requires(T&& t) {
     { t } -> APropertyReadable;
 
+    t.notify();
+
     // Property has operator= overloaded so it can be used in assignment statement.
     { t = std::declval<typename std::decay_t<T>::Underlying>() };
 };

--- a/aui.core/tests/PropertyDefTest.cpp
+++ b/aui.core/tests/PropertyDefTest.cpp
@@ -89,8 +89,11 @@ TEST_F(PropertyDefTest, Declaration) {
     //
     // For the rest, APropertyDef is identical to AProperty including seamless interaction:
     {
+        LogObserver mock;
+        EXPECT_CALL(mock, log(testing::_)).Times(2);
         // AUI_DOCS_CODE_BEGIN
         User u;
+        AObject::connect(u.name().changed, slot(mock)::log); // HIDE
         u.name() = "Hello";
         u.name() += " world!";
         EXPECT_EQ(u.name(), "Hello world!");

--- a/aui.core/tests/PropertyModifierTest.cpp
+++ b/aui.core/tests/PropertyModifierTest.cpp
@@ -1,0 +1,156 @@
+/*
+ * AUI Framework - Declarative UI toolkit for modern C++20
+ * Copyright (C) 2020-2024 Alex2772 and Contributors
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <gmock/gmock.h>
+#include <AUI/Common/AObject.h>
+#include "AUI/Common/AProperty.h"
+#include "AUI/Util/kAUI.h"
+
+class PropertyModifierTest: public testing::Test {};
+
+
+namespace {
+class LogObserver : public AObject {
+public:
+    LogObserver() {
+        ON_CALL(*this, log(testing::_)).WillByDefault([](const AString& msg) {
+        });
+    }
+    MOCK_METHOD(void, log, (const AString& msg), ());
+    MOCK_METHOD(void, observeString, (const AString&), ());
+    MOCK_METHOD(void, observeInt, (int), ());
+};
+}
+
+// AUI_DOCS_OUTPUT: doxygen/intermediate/property_modifier.h
+// @class aui::PropertyModifier
+//
+// Non-const operators of properties such as non-const versions of `operator=`, `operator+=`, `operator-=` have a side
+// effect of emitting `changed` signal upon operation completion. This ensures that modifying access to the property can
+// be observed.
+//
+TEST_F(PropertyModifierTest, Write_operators_observable1) {
+    LogObserver observer;
+    // AUI_DOCS_CODE_BEGIN
+    AProperty<int> counter = 0;
+    AObject::connect(counter.changed, slot(observer)::observeInt);
+    EXPECT_CALL(observer, observeInt(1)).Times(1);
+    counter += 1; // observable by observeInt
+    // AUI_DOCS_CODE_END
+}
+
+TEST_F(PropertyModifierTest, Write_operators_observable2) {
+    LogObserver observer;
+    // AUI_DOCS_CODE_BEGIN
+    AProperty<AString> name = "Hello";
+    AObject::connect(name.changed, slot(observer)::observeString);
+    EXPECT_CALL(observer, observeString("Hello world"_as)).Times(1);
+    name += " world"; // observable by observeString
+    // AUI_DOCS_CODE_END
+}
+
+//
+// @note Make sure your read-only operators (such as `operator+`, `operator-`) have marked const, otherwise property
+// would treat them as a writing access, resulting in unwanted signaling `changed` upon each access.
+TEST_F(PropertyModifierTest, Write_operators_const_access) {
+    LogObserver observer;
+    // AUI_DOCS_CODE_BEGIN
+    AProperty<int> counter = 0;
+    AObject::connect(counter.changed, slot(observer)::observeInt);
+    EXPECT_CALL(observer, observeInt(testing::_)).Times(0);
+    int nextCounter = counter + 1; // read-only access; noone is notified
+    // AUI_DOCS_CODE_END
+}
+
+//
+// ## Member access operator (operator->)
+// `operator->` is a special case. `operator->` having both non-const and const versions is a common practice, so
+// there's should be a way to distinguish between non-const access and const access, preferring the latter if possible.
+// The const version of `operator->` can be used directly on property:
+TEST_F(PropertyModifierTest, Write_operators_prefer_const_access) {
+    LogObserver observer;
+
+    // AUI_DOCS_CODE_BEGIN
+    EXPECT_CALL(observer, observeString(testing::_)).Times(0);
+    AProperty<AString> name = "Hello";
+    AObject::connect(name.changed, slot(observer)::observeString);
+
+    [[maybe_unused]] // HIDE
+    // returns const pointer
+    auto data = name->data();
+    // AUI_DOCS_CODE_END
+}
+
+// @ref property_system is designed in such a way you would explicitly express a modifying operation via binary equals
+// operator (and favours such as `+=`, `-=`):
+//
+TEST_F(PropertyModifierTest, Write_operators_write_equals) {
+    LogObserver observer;
+    // AUI_DOCS_CODE_BEGIN
+    AProperty<AString> name = "Hello";
+    AObject::connect(name.changed, slot(observer)::observeString);
+
+    EXPECT_CALL(observer, observeString("Test"_as)).Times(1);
+    name = "Test";
+    // AUI_DOCS_CODE_END
+}
+
+// However, it is still possible to achieve non-const version of `operator->`. To do this, you need a
+// @ref aui::PropertyModifier object that grants such access:
+
+TEST_F(PropertyModifierTest, Write_operators_write_operator_arrow1) {
+    LogObserver observer;
+    // AUI_DOCS_CODE_BEGIN
+    AProperty<AString> name = "Hello";
+    AObject::connect(name.changed, slot(observer)::observeString);
+
+    EXPECT_CALL(observer, observeString("Hell"_as)).Times(1);
+    name.writeScope()->removeAll('o');
+    // AUI_DOCS_CODE_END
+}
+
+//
+// You need to be careful when performing multiple operations at once. Design rationale behind `writeScope()` method
+// makes it painful (by intention) performing multiple accesses, since it would lead to unwanted change notifications
+// during the process:
+TEST_F(PropertyModifierTest, Write_operators_write_operator_arrow2) {
+    LogObserver observer;
+    AProperty<AString> name = "Hello";
+    AObject::connect(name.changed, slot(observer)::observeString);
+
+    // AUI_DOCS_CODE_BEGIN
+    // WRONG WAY
+    EXPECT_CALL(observer, observeString("Hell"_as)).Times(1);
+    name.writeScope()->removeAll('o');
+
+    EXPECT_CALL(observer, observeString("He"_as)).Times(1);
+    name.writeScope()->removeAll('l');
+    // AUI_DOCS_CODE_END
+}
+
+//
+// The right way is to create @ref aui::PropertyModifier just once. This will produce exactly one notification, ensuring
+// that modifications to the property are performed atomically. This means that all operations within
+// the scope of @ref aui::PropertyModifier produced by `writeScope()` will be treated as one unit, and only one change
+// notification will be emitted.
+TEST_F(PropertyModifierTest, Write_operators_write_operator_arrow3) {
+    LogObserver observer;
+    AProperty<AString> name = "Hello";
+    AObject::connect(name.changed, slot(observer)::observeString);
+
+    // AUI_DOCS_CODE_BEGIN
+    // RIGHT WAY
+    EXPECT_CALL(observer, observeString("He"_as)).Times(1);
+    auto nameWriteable = name.writeScope();
+    nameWriteable->removeAll('o');
+    nameWriteable->removeAll('l');
+    // AUI_DOCS_CODE_END
+}

--- a/aui.core/tests/PropertyTest.cpp
+++ b/aui.core/tests/PropertyTest.cpp
@@ -321,39 +321,4 @@ TEST_F(PropertyTest, Moving_AProperty) { // HEADER_H1
 }
 
 // # Non-const operators {#PropertyTest_Write_operators}
-// Non-const operators such as non-const versions of `operator->`, `operator=`, `operator+=`, `operator-=` have a
-// side effect of emitting `changed` signal upon operation completion. This ensures that modifying access to the
-// property can be observed.
-TEST_F(PropertyTest, Write_operators_observable1) {
-    LogObserver observer;
-    EXPECT_CALL(observer, observeInt(1)).Times(1);
-    // AUI_DOCS_CODE_BEGIN
-    AProperty<int> counter = 0;
-    AObject::connect(counter.changed, slot(observer)::observeInt);
-    counter += 1; // observable by observeInt
-    // AUI_DOCS_CODE_END
-}
-
-TEST_F(PropertyTest, Write_operators_observable2) {
-    LogObserver observer;
-    AProperty<AString> name = "Hello";
-    AObject::connect(name.changed, slot(observer)::observeString);
-    EXPECT_CALL(observer, observeString("Hello world"_as)).Times(1);
-    name += " world";
-}
-
-TEST_F(PropertyTest, Write_operators_prefer_const_access) {
-    LogObserver observer;
-    EXPECT_CALL(observer, observeString(testing::_)).Times(0);
-    AProperty<AString> name = "Hello";
-    AObject::connect(name.changed, slot(observer)::observeString);
-    [[maybe_unused]] auto data = name->data();
-}
-
-TEST_F(PropertyTest, Write_operators_write_operator_arrow) {
-    LogObserver observer;
-    AProperty<AString> name = "Hello";
-    AObject::connect(name.changed, slot(observer)::observeString);
-    EXPECT_CALL(observer, observeString(""_as)).Times(1);
-    name.writeScope()->clear();
-}
+// Refer to @ref aui::PropertyModifier.

--- a/aui.core/tests/PropertyTest.cpp
+++ b/aui.core/tests/PropertyTest.cpp
@@ -62,13 +62,21 @@ TEST_F(PropertyTest, Declaration) {
 
     // You can even perform binary operations on it seamlessly:
     {
+        LogObserver mock;
+        EXPECT_CALL(mock, log(testing::_)).Times(2);
         // AUI_DOCS_CODE_BEGIN
         User u;
+        AObject::connect(u.name.changed, slot(mock)::log); // HIDE
         u.name = "Hello";
         u.name += " world!";
         EXPECT_EQ(u.name, "Hello world!");
         EXPECT_EQ(u.name->length(), AString("Hello world!").length());
         // AUI_DOCS_CODE_END
+
+        /* does this trigger notify()? */
+        [[maybe_unused]] auto t = u.name->size();
+
+        EXPECT_EQ(t, 12);
     }
 
     // In most cases, property is implicitly convertible to its underlying type:

--- a/aui.updater/src/AUI/Updater/AUpdater.h
+++ b/aui.updater/src/AUI/Updater/AUpdater.h
@@ -172,7 +172,7 @@ public:
      * @brief Downloading state.
      */
     struct StatusDownloading {
-        AProperty<aui::float_within_0_1> progress;
+        mutable AProperty<aui::float_within_0_1> progress;
     };
 
     /**


### PR DESCRIPTION
This PR addresses [the problem](https://github.com/aui-framework/aui/issues/81#issuecomment-2606939457) raised by @na2axl:
> Is there a reason why AProperty doesn't have a non-const overload for operator -> ?

In `develop`, `AProperty` has broken notification behaviour with `operator+=` and `operator->`, this PR resolves the problem by introducing temporary object which notifies the property upon destruction