### PR TITLE
OpenGL benchmark

### DIFF
--- a/aui.uitests/CMakeLists.txt
+++ b/aui.uitests/CMakeLists.txt
@@ -13,3 +13,4 @@ if (TARGET GTest::gmock)
 endif()
 
 aui_enable_tests(aui.uitests)
+aui_enable_benchmarks(aui.uitests)

--- a/aui.uitests/benchmarks/UIBenchmarkScene.h
+++ b/aui.uitests/benchmarks/UIBenchmarkScene.h
@@ -1,0 +1,168 @@
+/*
+ * AUI Framework - Declarative UI toolkit for modern C++20
+ * Copyright (C) 2020-2024 Alex2772 and Contributors
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include "AUI/View/AView.h"
+#include "AUI/Util/UIBuildingHelpers.h"
+#include "AUI/View/AGroupBox.h"
+#include "AUI/View/AButton.h"
+#include "AUI/View/ACheckBox.h"
+#include "AUI/View/ARadioGroup.h"
+#include "AUI/View/ADropdownList.h"
+#include "AUI/View/ADragArea.h"
+#include "AUI/View/AProgressBar.h"
+#include "AUI/View/ACircleProgressBar.h"
+#include "AUI/View/ASlider.h"
+#include "AUI/View/ANumberPicker.h"
+#include "AUI/View/ATextField.h"
+#include "AUI/View/ADoubleNumberPicker.h"
+#include "AUI/View/AScrollArea.h"
+#include "AUI/View/ATextArea.h"
+
+static _<AView> uiBenchmarkScene() {
+    using namespace declarative;
+    using namespace ass;
+
+    return Horizontal {
+        Vertical {
+          // buttons
+          GroupBox {
+            Label { "Buttons" },
+            Vertical {
+              _new<AButton>("Common button"),
+              _new<AButton>("Default button") let { it->setDefault(); },
+              _new<AButton>("Disabled button") let { it->setDisabled(); },
+              Button {
+                Label { "Button with icon" },
+              },
+            },
+          },
+
+          // checkboxes
+          GroupBox {
+            CheckBoxWrapper { Label { "Checkboxes" } } let { it->checked() = true; },
+            Vertical {
+              CheckBoxWrapper { Label { "Unchecked checkbox" } },
+              CheckBoxWrapper { Label { "Checked checkbox" } } let { it->checked() = true; },
+              CheckBoxWrapper { Label { "Disabled checkbox" } } let { it->setDisabled(); },
+            },
+          },
+
+          // radiobuttons
+          GroupBox {
+            Label { "Radiobuttons" },
+            RadioGroup {
+              RadioButton { "Radiobutton 1" } let { it->checked() = true; },
+              RadioButton { "Radiobutton 2" },
+              RadioButton { "Radiobutton 3" },
+              RadioButton { "Disabled radiobutton" } let { it->disable(); },
+            },
+          },
+
+          // comboboxes
+          GroupBox {
+            Label { "Comboboxes" },
+            Vertical {
+              _new<ADropdownList>(AListModel<AString>::make({
+                "Combobox 1",
+                "Combobox 2",
+                "Combobox 3",
+                "Combobox 4",
+                "Combobox 5",
+                "Combobox 6",
+              })),
+              _new<ADropdownList>(AListModel<AString>::make({ "Disabled combobox" })) let { it->setDisabled(); },
+            },
+          },
+          GroupBox {
+            Label { "Drag area" },
+
+            _new<ADragArea>() let {
+                    it with_style {
+                        MinSize { 100_dp },
+                        Border { 1_px, 0x0_rgb },
+                    };
+                    it->addView(ADragArea::convertToDraggable(_new<AButton>("Drag me!"), false));
+                },
+          } with_style { Expanding {} },
+        },
+        Vertical {
+          GroupBox {
+            Label { "Window factory" },
+            Vertical {
+              // CheckBoxWrapper { Label { "Resizeable" } }, TODO
+              _new<AButton>("Show window"),
+              _new<AButton>("Show window without caption"),
+              _new<AButton>("Show window custom caption"),
+              _new<AButton>("Close all windows"),
+            },
+          },
+
+          GroupBox {
+            Label { "System dialog" },
+            Vertical {
+              _new<AButton>("Show file chooser"),
+              _new<AButton>("Show folder chooser"),
+              _new<AButton>("Message box"),
+              _new<AButton>("Cause assertion fail"),
+              _new<AButton>("Cause hang"),
+              _new<AButton>("Cause access violation"),
+            },
+          },
+        },
+        Vertical::Expanding {
+          // fields
+          GroupBox {
+            Label { "Progressbar" },
+            Vertical {
+              _new<AProgressBar>(),
+              _new<ACircleProgressBar>(),
+              GroupBox {
+                Label { "Slider" },
+                Vertical {
+                  _new<ASlider>(),
+                },
+              },
+            },
+          },
+          GroupBox {
+            Label { "Scaling factor" },
+            Horizontal {
+              _new<ANumberPicker>(),
+              Label { "x0.25" },
+            },
+          },
+          GroupBox {
+            Label { "Fields" },
+            Vertical::Expanding {
+              Label { "Text field" },
+              _new<ATextField>() let { it->focus(); },
+              Label { "Number picker" },
+              _new<ANumberPicker>(),
+              _new<ADoubleNumberPicker>(),
+              Label { "Text area" },
+              AScrollArea::Builder()
+                      .withContents(_new<ATextArea>(
+                          "AUI Framework - Declarative UI toolkit for modern C++20\n"
+                          "Copyright (C) 2020-2024 Alex2772 and Contributors\n"
+                          "\n"
+                          "SPDX-License-Identifier: MPL-2.0\n"
+                          "\n"
+                          "This Source Code Form is subject to the terms of the Mozilla "
+                          "Public License, v. 2.0. If a copy of the MPL was not distributed with this "
+                          "file, You can obtain one at http://mozilla.org/MPL/2.0/."))
+                      .build()
+                  << ".input-field" let { it->setExpanding(); },
+            } },
+        },
+    };
+}

--- a/aui.uitests/benchmarks/UIOpenGLBenchmark.cpp
+++ b/aui.uitests/benchmarks/UIOpenGLBenchmark.cpp
@@ -1,0 +1,47 @@
+/*
+ * AUI Framework - Declarative UI toolkit for modern C++20
+ * Copyright (C) 2020-2024 Alex2772 and Contributors
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <benchmark/benchmark.h>
+#include "UIBenchmarkScene.h"
+#include "AUI/Platform/ARenderingContextOptions.h"
+#include "AUI/Image/png/PngImageLoader.h"
+#include "AUI/GL/OpenGLRenderer.h"
+
+static void OpenGLRendering(benchmark::State& state) {
+
+    ARenderingContextOptions::set({
+      .initializationOrder {
+        ARenderingContextOptions::OpenGL {},
+      },
+      .flags = ARenderContextFlags::NO_SMOOTH | ARenderContextFlags::NO_VSYNC,
+    });
+
+    _<AWindow> window;
+    try {
+        window = _new<AWindow>();
+        window->show();
+    } catch (const AException& e) {
+        ALogger::info("OpenGLRendererTest") << "GPU is not available; skipping test\n" << e;
+        return;
+    }
+
+    window->setContents(Centered { uiBenchmarkScene() });
+    window->pack();
+
+    AUI_ASSERT(dynamic_cast<OpenGLRenderer*>(&AWindow::current()->getRenderingContext()->renderer()));
+
+    for (auto _ : state) {
+        window->redraw();
+    }
+    PngImageLoader::save(AFileOutputStream("benchmark_OpenGLRendering.png"), window->getRenderingContext()->makeScreenshot());
+}
+
+BENCHMARK(OpenGLRendering);

--- a/aui.uitests/src/AUI/Test/UI/UITestCase.cpp
+++ b/aui.uitests/src/AUI/Test/UI/UITestCase.cpp
@@ -117,6 +117,7 @@ void testing::UITest::TearDown() {
     AWindow::destroyWindowManager();
 
     Test::TearDown();
+    UITestState::endUITest();
 }
 void testing::UITest::saveScreenshot(const AString& name) {
     auto i = testing::UnitTest::GetInstance();

--- a/aui.uitests/tests/UIOpenGLRendererTest.cpp
+++ b/aui.uitests/tests/UIOpenGLRendererTest.cpp
@@ -23,6 +23,10 @@ protected:
     void SetUp() override {
         Test::SetUp();
 
+        if (std::getenv("CI")) {
+            GTEST_SKIP() << "Disabled on CI";
+        }
+
         ARenderingContextOptions::set({
           .initializationOrder {
             ARenderingContextOptions::OpenGL {},

--- a/aui.uitests/tests/UIOpenGLRendererTest.cpp
+++ b/aui.uitests/tests/UIOpenGLRendererTest.cpp
@@ -1,0 +1,54 @@
+/*
+ * AUI Framework - Declarative UI toolkit for modern C++20
+ * Copyright (C) 2020-2024 Alex2772 and Contributors
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include <gmock/gmock.h>
+#include "AUI/UITest.h"
+#include "AUI/GL/OpenGLRenderer.h"
+#include "AUI/Util/UIBuildingHelpers.h"
+
+using namespace ass;
+
+class UIOpenGLRendererTest : public testing::Test {
+public:
+
+protected:
+    void SetUp() override {
+        Test::SetUp();
+
+        ARenderingContextOptions::set({
+          .initializationOrder {
+            ARenderingContextOptions::OpenGL {},
+          },
+          .flags = ARenderContextFlags::NO_SMOOTH | ARenderContextFlags::NO_VSYNC,
+        });
+
+        try {
+            mWindow = _new<AWindow>();
+            mWindow->show();
+        } catch (const AException& e) {
+            do_once { ALogger::info("OpenGLRendererTest") << "GPU is not available; skipping test\n" << e; }
+            GTEST_SKIP() << "GPU is not available";
+        }
+    }
+    void TearDown() override { Test::TearDown(); }
+    _<AWindow> mWindow;
+};
+
+TEST_F(UIOpenGLRendererTest, CheckRenderer) {
+    EXPECT_TRUE(dynamic_cast<OpenGLRenderer*>(&AWindow::current()->getRenderingContext()->renderer()));
+    mWindow->setContents(Centered {
+      _new<AView>() with_style {
+        BackgroundSolid { AColor::RED },
+        FixedSize { 32_dp },
+      } << ".test",
+    });
+    By::name(".test").check(averageColor(AColor::RED));
+}

--- a/aui.views/src/AUI/Platform/linux/OpenGLRenderingContextImpl.cpp
+++ b/aui.views/src/AUI/Platform/linux/OpenGLRenderingContextImpl.cpp
@@ -191,5 +191,13 @@ void OpenGLRenderingContext::endResize(AWindowBase& window) {
 }
 
 AImage OpenGLRenderingContext::makeScreenshot() {
-    return AImage();
+    if (auto fb = std::get_if<gl::Framebuffer>(&mFramebuffer)) {
+        fb->bindForRead();
+        AImage result(mViewportSize, APixelFormat::RGBA_BYTE);
+        glReadPixels(0, 0, result.width(), result.height(), GL_RGBA, GL_UNSIGNED_BYTE, static_cast<void*>(result.modifiableBuffer().data()));
+        result.mirrorVertically();
+        gl::Framebuffer::unbind();
+        return result;
+    }
+    return {};
 }

--- a/aui.views/src/AUI/Platform/linux/OpenGLRenderingContextImpl.cpp
+++ b/aui.views/src/AUI/Platform/linux/OpenGLRenderingContextImpl.cpp
@@ -24,45 +24,57 @@
 #include <AUI/GL/State.h>
 #include <GL/glx.h>
 
-
 /* Typedef for the GL 3.0 context creation function */
-typedef GLXContext (*PFNGLXCREATECONTEXTATTRIBSARBPROC)(Display *dpy,
-                                                        GLXFBConfig config,
-                                                        GLXContext
-                                                        share_context,
-                                                        Bool direct,
-                                                        const int
-                                                        *attrib_list);
+typedef GLXContext (*PFNGLXCREATECONTEXTATTRIBSARBPROC)(
+    Display* dpy, GLXFBConfig config, GLXContext share_context, Bool direct, const int* attrib_list);
 static PFNGLXCREATECONTEXTATTRIBSARBPROC glXCreateContextAttribsARB = nullptr;
 
+typedef void (*PFNGLXSWAPINTERVALEXTPROC)(Display* dpy, GLXDrawable drawable, int interval);
+static PFNGLXSWAPINTERVALEXTPROC glXSwapIntervalEXT = nullptr;
 
 GLXContext OpenGLRenderingContext::ourContext = nullptr;
 
-OpenGLRenderingContext::~OpenGLRenderingContext() {
-}
+OpenGLRenderingContext::~OpenGLRenderingContext() {}
 
 void OpenGLRenderingContext::init(const Init& init) {
     CommonRenderingContext::init(init);
     static XSetWindowAttributes swa;
     static XVisualInfo* vi;
     if (ourContext == nullptr) {
-        glXCreateContextAttribsARB = reinterpret_cast<PFNGLXCREATECONTEXTATTRIBSARBPROC>(glXGetProcAddress(reinterpret_cast<const GLubyte*>("glXCreateContextAttribsARB")));
+        glXCreateContextAttribsARB = reinterpret_cast<PFNGLXCREATECONTEXTATTRIBSARBPROC>(
+            glXGetProcAddress(reinterpret_cast<const GLubyte*>("glXCreateContextAttribsARB")));
 
-        GLint att[] = {GLX_X_RENDERABLE, True, // 1
-                       GLX_DRAWABLE_TYPE, GLX_WINDOW_BIT, // 3
-                       GLX_RENDER_TYPE, GLX_RGBA_BIT, // 5
-                       GLX_X_VISUAL_TYPE, GLX_TRUE_COLOR, // 7
-                       GLX_RED_SIZE, 8, // 9
-                       GLX_GREEN_SIZE, 8, // 11
-                       GLX_BLUE_SIZE, 8, // 13
-                       GLX_ALPHA_SIZE, 8, // 15
-                       GLX_DEPTH_SIZE, 24,
-                       GLX_STENCIL_SIZE, 8,
-                       GLX_DOUBLEBUFFER, true,
-                       GLX_STENCIL_SIZE, 8,
-                       GLX_SAMPLE_BUFFERS  , 0,
-                       GLX_SAMPLES         , 0,
-                       None};
+        GLint att[] = {
+            GLX_X_RENDERABLE,
+            True,   // 1
+            GLX_DRAWABLE_TYPE,
+            GLX_WINDOW_BIT,   // 3
+            GLX_RENDER_TYPE,
+            GLX_RGBA_BIT,   // 5
+            GLX_X_VISUAL_TYPE,
+            GLX_TRUE_COLOR,   // 7
+            GLX_RED_SIZE,
+            8,   // 9
+            GLX_GREEN_SIZE,
+            8,   // 11
+            GLX_BLUE_SIZE,
+            8,   // 13
+            GLX_ALPHA_SIZE,
+            8,   // 15
+            GLX_DEPTH_SIZE,
+            24,
+            GLX_STENCIL_SIZE,
+            8,
+            GLX_DOUBLEBUFFER,
+            true,
+            GLX_STENCIL_SIZE,
+            8,
+            GLX_SAMPLE_BUFFERS,
+            0,
+            GLX_SAMPLES,
+            0,
+            None
+        };
 
         int fbcount;
         GLXFBConfig* fbc = glXChooseFBConfig(ourDisplay, DefaultScreen(ourDisplay), att, &fbcount);
@@ -71,11 +83,12 @@ void OpenGLRenderingContext::init(const Init& init) {
             // try to reduce system requirements
             size_t indexToReduce = std::size(att) - 2;
             do {
-                ALogger::warn("[OpenGL compatibility] Reduced OpenGL requirements: pass {}"_format((std::size(att) - indexToReduce) / 2 - 1));
+                ALogger::warn("[OpenGL compatibility] Reduced OpenGL requirements: pass {}"_format(
+                    (std::size(att) - indexToReduce) / 2 - 1));
                 att[indexToReduce] = 0;
                 indexToReduce -= 2;
                 fbc = glXChooseFBConfig(ourDisplay, DefaultScreen(ourDisplay), att, &fbcount);
-            } while ((fbc == nullptr || fbcount <= 0) && indexToReduce > 13); // up to GLX_BLUE_SIZE
+            } while ((fbc == nullptr || fbcount <= 0) && indexToReduce > 13);   // up to GLX_BLUE_SIZE
 
             if (fbc == nullptr || fbcount <= 0) {
                 // try to disable rgba.
@@ -98,7 +111,6 @@ void OpenGLRenderingContext::init(const Init& init) {
 
         int best_fbc = 0;
 
-
         for (int i = 0; i < fbcount; ++i) {
             vi = glXGetVisualFromFBConfig(ourDisplay, fbc[i]);
             if (vi) {
@@ -108,7 +120,6 @@ void OpenGLRenderingContext::init(const Init& init) {
                     best_fbc = i;
                     break;
                 }
-
             }
             XFree(vi);
         }
@@ -122,13 +133,17 @@ void OpenGLRenderingContext::init(const Init& init) {
         vi = glXGetVisualFromFBConfig(ourDisplay, bestFbc);
         auto cmap = XCreateColormap(ourDisplay, ourScreen->root, vi->visual, AllocNone);
         swa.colormap = cmap;
-        swa.event_mask = ExposureMask | KeyPressMask | KeyReleaseMask | ButtonPressMask | ButtonReleaseMask | StructureNotifyMask
-                         | PointerMotionMask | StructureNotifyMask | PropertyChangeMask | StructureNotifyMask;
+        swa.event_mask =
+            ExposureMask | KeyPressMask | KeyReleaseMask | ButtonPressMask | ButtonReleaseMask | StructureNotifyMask |
+            PointerMotionMask | StructureNotifyMask | PropertyChangeMask | StructureNotifyMask;
         if (glXCreateContextAttribsARB) {
             int attribList[] = {
-                GLX_CONTEXT_MAJOR_VERSION_ARB, 3,
-                GLX_CONTEXT_MINOR_VERSION_ARB, 3,
-                GLX_CONTEXT_PROFILE_MASK_ARB, GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
+                GLX_CONTEXT_MAJOR_VERSION_ARB,
+                3,
+                GLX_CONTEXT_MINOR_VERSION_ARB,
+                3,
+                GLX_CONTEXT_PROFILE_MASK_ARB,
+                GLX_CONTEXT_COMPATIBILITY_PROFILE_BIT_ARB,
                 None,
             };
             ourContext = glXCreateContextAttribsARB(ourDisplay, bestFbc, nullptr, true, attribList);
@@ -151,6 +166,18 @@ void OpenGLRenderingContext::init(const Init& init) {
     if (init.parent) {
         XSetTransientForHint(ourDisplay, init.window.mHandle, init.parent->mHandle);
     }
+
+    // vsync
+    do_once {
+        glXSwapIntervalEXT = reinterpret_cast<PFNGLXSWAPINTERVALEXTPROC>(
+            glXGetProcAddress(reinterpret_cast<const GLubyte*>("glXSwapIntervalEXT")));
+    }
+
+    if (glXSwapIntervalEXT) {
+        glXSwapIntervalEXT(
+            ourDisplay, init.window.mHandle, !(ARenderingContextOptions::get().flags & ARenderContextFlags::NO_VSYNC));
+    }
+
     mRenderer = ourRenderer();
 }
 

--- a/aui.views/src/AUI/UITestState.cpp
+++ b/aui.views/src/AUI/UITestState.cpp
@@ -26,3 +26,6 @@ bool UITestState::isTesting() {
 void UITestState::beginUITest() {
     ourIsUITest = true;
 }
+void UITestState::endUITest() {
+    ourIsUITest = false;
+}

--- a/aui.views/src/AUI/UITestState.h
+++ b/aui.views/src/AUI/UITestState.h
@@ -16,4 +16,5 @@
 namespace UITestState {
     API_AUI_VIEWS bool isTesting();
     API_AUI_VIEWS void beginUITest();
+    API_AUI_VIEWS void endUITest();
 };


### PR DESCRIPTION
Added a benchmark that involves drawing small scene with OpenGL (GPU).

![benchmark_OpenGLRendering](https://github.com/user-attachments/assets/5a6b4acd-d888-4523-b6d1-0ee40ad8a809)

Not sure how to implement GPU scaling though.


```
/home/alex2772/CLionProjects/aui/cmake-build-relwithdebinfo/bin/Benchmarks --benchmark_filter=OpenGL*
2025-02-26T11:03:19+03:00
Running /home/alex2772/CLionProjects/aui/cmake-build-relwithdebinfo/bin/Benchmarks
Run on (32 X 6131 MHz CPU s)
CPU Caches:
  L1 Data 32 KiB (x16)
  L1 Instruction 32 KiB (x16)
  L2 Unified 512 KiB (x16)
  L3 Unified 32768 KiB (x2)
Load Average: 26.17, 12.27, 7.17
***WARNING*** CPU scaling is enabled, the benchmark real time measurements may be noisy and will incur extra overhead.
[11:03:19][][Logger][INFO]: Log file: /tmp/aui.1751220.log
[11:03:19][][INFO]: OpenGL context is ready
[11:03:19][][OpenGLRenderer][INFO]: GL_VERSION = 4.6.0 NVIDIA 565.77
[11:03:19][][OpenGLRenderer][INFO]: GL_VENDOR = NVIDIA Corporation
[11:03:19][][OpenGLRenderer][INFO]: GL_RENDERER = NVIDIA GeForce RTX 4090/PCIe/SSE2
[11:03:19][][FontManager][INFO]: Using gtk theme font: SF UI Display Med (file:///home/alex2772/.fonts/s/SFUIDisplay_Medium.otf)
----------------------------------------------------------
Benchmark                Time             CPU   Iterations
----------------------------------------------------------
OpenGLRendering     581255 ns       567553 ns         1113

Process finished with exit code 0
```