### PR TITLE
get rid of AUI_IGNORE_OPENSSL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,7 +186,7 @@ jobs:
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-        run: cmake -G "${{ matrix.generator }}" -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.debug_or_release}} -DBUILD_SHARED_LIBS=${{ matrix.shared_or_static == 'shared' && 'ON' || 'OFF' }} ${{matrix.additional_cmake_flags}} -DAUI_IGNORE_OPENSSL=TRUE -DAUIB_PRODUCED_PACKAGES_SELF_SUFFICIENT=ON -DAUI_BUILD_AUDIO=OFF
+        run: cmake -G "${{ matrix.generator }}" -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.debug_or_release}} -DBUILD_SHARED_LIBS=${{ matrix.shared_or_static == 'shared' && 'ON' || 'OFF' }} ${{matrix.additional_cmake_flags}} -DAUIB_PRODUCED_PACKAGES_SELF_SUFFICIENT=ON -DAUI_BUILD_AUDIO=OFF
 
       - name: Build project
         # Build your program with the given configuration
@@ -260,7 +260,7 @@ jobs:
 
       - name: Configure test app
         run: |
-          cmake -G "${{ matrix.generator }}" -B ${{github.workspace}}/build -S ${{github.workspace}}/test/minimal_deployment_test -DCMAKE_BUILD_TYPE=${{matrix.debug_or_release}} -DBUILD_SHARED_LIBS=${{ matrix.shared_or_static == 'shared' && 'ON' || 'OFF' }} -DAUI_IGNORE_OPENSSL=TRUE -DARTIFACTS_DIR=${{github.workspace}}/artifacts -DAUI_APP_PACKAGING=AUI_PORTABLE_ZIP
+          cmake -G "${{ matrix.generator }}" -B ${{github.workspace}}/build -S ${{github.workspace}}/test/minimal_deployment_test -DCMAKE_BUILD_TYPE=${{matrix.debug_or_release}} -DBUILD_SHARED_LIBS=${{ matrix.shared_or_static == 'shared' && 'ON' || 'OFF' }} -DARTIFACTS_DIR=${{github.workspace}}/artifacts -DAUI_APP_PACKAGING=AUI_PORTABLE_ZIP
 
       - name: Build test app
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-        run: CC=/usr/bin/clang CXX=/usr/bin/clang++  cmake -GNinja -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=OFF -DAUI_IGNORE_OPENSSL=TRUE  -DCMAKE_CXX_CLANG_TIDY=/usr/bin/clang-tidy -DCMAKE_CXX_FLAGS="-stdlib=libc++ -std=c++20"
+        run: CC=/usr/bin/clang CXX=/usr/bin/clang++  cmake -GNinja -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_SHARED_LIBS=OFF -DCMAKE_CXX_CLANG_TIDY=/usr/bin/clang-tidy -DCMAKE_CXX_FLAGS="-stdlib=libc++ -std=c++20"
 
       - name: Run tidy
         # Build your program with the given configuration
@@ -73,7 +73,7 @@ jobs:
       - name: Configure CMake asan
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-        run: cmake -GNinja -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -DAUI_IGNORE_OPENSSL=TRUE  -DAUI_ENABLE_DEATH_TESTS=FALSE
+        run: cmake -GNinja -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS=OFF -DAUI_ENABLE_DEATH_TESTS=FALSE
 
       - name: Build project asan
         # Build your program with the given configuration

--- a/.github/workflows/deployment-test.yml
+++ b/.github/workflows/deployment-test.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Configure CMake
         # Configure CMake in a 'build' subdirectory. `CMAKE_BUILD_TYPE` is only required if you are using a single-configuration generator such as make.
         # See https://cmake.org/cmake/help/latest/variable/CMAKE_BUILD_TYPE.html?highlight=cmake_build_type
-        run: cmake -G "${{ matrix.generator }}" -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.debug_or_release}} -DBUILD_SHARED_LIBS=${{ matrix.shared_or_static == 'shared' && 'ON' || 'OFF' }} ${{matrix.additional_cmake_flags}} -DAUI_IGNORE_OPENSSL=TRUE -DAUI_TEST_DEPLOY_VERSION="${{ env.TAG }}" -DAUIB_PRODUCED_PACKAGES_SELF_SUFFICIENT=ON -DAUI_BUILD_AUDIO=OFF
+        run: cmake -G "${{ matrix.generator }}" -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.debug_or_release}} -DBUILD_SHARED_LIBS=${{ matrix.shared_or_static == 'shared' && 'ON' || 'OFF' }} ${{matrix.additional_cmake_flags}} -DAUI_TEST_DEPLOY_VERSION="${{ env.TAG }}" -DAUIB_PRODUCED_PACKAGES_SELF_SUFFICIENT=ON -DAUI_BUILD_AUDIO=OFF
 
       - name: Run tests
         # Build your program with the given configuration

--- a/aui.crypt/CMakeLists.txt
+++ b/aui.crypt/CMakeLists.txt
@@ -3,21 +3,6 @@ cmake_minimum_required(VERSION 3.10)
 
 auib_import(OpenSSL https://github.com/aui-framework/openssl-cmake/archive/56ee19b7e11b418e0f29825414abdca96ff6b83e.zip ARCHIVE)
 
-# https://github.com/aui-framework/aui/issues/84
-get_target_property(_l OpenSSL::Crypto IMPORTED_LOCATION)
-if (_l)
-    if (NOT _l MATCHES "^${AUIB_CACHE_DIR}")
-        message(FATAL_ERROR "Internal AUI error: OpenSSL links to the system library (${_l}).")
-    endif()
-endif()
-
-get_target_property(_l OpenSSL::Crypto IMPORTED_LOCATION_DEBUG)
-if (_l AND NOT AUI_IGNORE_OPENSSL)
-    if(NOT LIB_EAY_DEBUG MATCHES "^${AUIB_CACHE_DIR}")
-        message(FATAL_ERROR "CMake linked to manually installed OpenSSL at ${LIB_EAY_DEBUG}. This library should be removed otherwise runtime linking may be broken. Set AUI_IGNORE_OPENSSL=TRUE to ignore.")
-    endif()
-endif()
-
 aui_module(aui.crypt EXPORT aui)
 aui_enable_tests(aui.crypt)
 aui_link(aui.crypt PUBLIC aui::core)


### PR DESCRIPTION
`AUI_IGNORE_OPENSSL` is an outdated undocumented check that OpenSSL pulled by aui.boot is actually located in ~/.aui, instead of using the system one.

AUI.Boot now implements this feature by itself [VALIDATION_LEVEL](https://aui-framework.github.io/develop/md_docs_2AUI_01Boot.html#auib_validation_level).