### PR TITLE
Feat/layout optimizations

### DIFF
--- a/aui.core/src/AUI/Common/AObject.h
+++ b/aui.core/src/AUI/Common/AObject.h
@@ -289,7 +289,8 @@ public:
         }
     }
 
-    _<AAbstractThread> getThread() const { return mAttachedThread; }
+    [[nodiscard]]
+    const _<AAbstractThread>& getThread() const noexcept { return mAttachedThread; }
 
     bool isSlotsCallsOnlyOnMyThread() const noexcept { return mSlotsCallsOnlyOnMyThread; }
 

--- a/aui.core/src/AUI/Thread/AThread.cpp
+++ b/aui.core/src/AUI/Thread/AThread.cpp
@@ -194,7 +194,7 @@ void AThread::sleep(std::chrono::milliseconds duration) {
 
 AAbstractThread::id AAbstractThread::getId() const { return mId; }
 
-_<AAbstractThread> AThread::current() {
+const _<AAbstractThread>& AThread::current() {
     auto& t = threadStorage();
     if (t == nullptr)   // abstract thread
     {

--- a/aui.core/src/AUI/Thread/AThread.h
+++ b/aui.core/src/AUI/Thread/AThread.h
@@ -228,7 +228,8 @@ public:
     /**
      * @return current thread.
      */
-    static _<AAbstractThread> current();
+    [[nodiscard]]
+    static const _<AAbstractThread>& current();
 
     /**
      * @brief Interruption point


### PR DESCRIPTION
```
Comparing Layout* (from ./Benchmarks.old) to Layout* (from ./Benchmarks)
Benchmark                               Time             CPU      Time Old      Time New       CPU Old       CPU New
--------------------------------------------------------------------------------------------------------------------
[Layout* vs. Layout*]                -0.0793         -0.0783       1396361       1285584       1374697       1267104
OVERALL_GEOMEAN                      -0.0793         -0.0783             0             0             0             0
```