### PR TITLE
Use `std::snprintf` instead of `sprintf`

### DIFF
--- a/aui.core/src/AUI/Common/AByteBuffer.cpp
+++ b/aui.core/src/AUI/Common/AByteBuffer.cpp
@@ -116,7 +116,9 @@ std::ostream& operator<<(std::ostream& o, AByteBufferView buffer)
     o << '[';
     for (auto c : buffer)
     {
-        sprintf(formatBuf, "%02x ", std::uint8_t(c));
+        std::snprintf(formatBuf, sizeof(formatBuf), "%02x ",
+            static_cast<unsigned>(static_cast<uint8_t>(c))
+        );
         o << formatBuf;
     }
     o << ']';

--- a/aui.core/src/AUI/Common/AColor.cpp
+++ b/aui.core/src/AUI/Common/AColor.cpp
@@ -75,8 +75,12 @@ AColor::AColor(const AString& s) {
 
 AString AColor::toString() const {
     char buf[16];
-    sprintf(buf, "#%02x%02x%02x%02x", static_cast<unsigned char>(r * 255.f), static_cast<unsigned char>(g * 255.f),
-            static_cast<unsigned char>(b * 255.f), static_cast<unsigned char>(a * 255.f));
+    std::snprintf(buf, sizeof(buf), "#%02x%02x%02x%02x",
+        static_cast<unsigned>(static_cast<unsigned char>(r * 255.f)),
+        static_cast<unsigned>(static_cast<unsigned char>(g * 255.f)),
+        static_cast<unsigned>(static_cast<unsigned char>(b * 255.f)),
+        static_cast<unsigned>(static_cast<unsigned char>(a * 255.f))
+    );
     return buf;
 }
 

--- a/aui.core/src/AUI/Common/AString.cpp
+++ b/aui.core/src/AUI/Common/AString.cpp
@@ -1173,7 +1173,7 @@ AString AString::restrictLength(size_t s, const AString& stringAtEnd) const {
 
 AString AString::numberHex(int i) noexcept {
     char buf[32];
-    sprintf(buf, "%x", i);
+    std::snprintf(buf, sizeof(buf), "%x", static_cast<unsigned>(i));
     return buf;
 }
 

--- a/aui.core/src/AUI/Common/AUuid.cpp
+++ b/aui.core/src/AUI/Common/AUuid.cpp
@@ -54,48 +54,48 @@ uint8_t AUuid::fromHex(char c) {
 
 AString AUuid::toString() const {
     char str[40];
-    sprintf(str,
-            "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
-            mData[0],
-            mData[1],
-            mData[2],
-            mData[3],
-            mData[4],
-            mData[5],
-            mData[6],
-            mData[7],
-            mData[8],
-            mData[9],
-            mData[10],
-            mData[11],
-            mData[12],
-            mData[13],
-            mData[14],
-            mData[15]
-            );
+    std::snprintf(str, sizeof(str),
+        "%02x%02x%02x%02x-%02x%02x-%02x%02x-%02x%02x-%02x%02x%02x%02x%02x%02x",
+        static_cast<unsigned>(mData[0]),
+        static_cast<unsigned>(mData[1]),
+        static_cast<unsigned>(mData[2]),
+        static_cast<unsigned>(mData[3]),
+        static_cast<unsigned>(mData[4]),
+        static_cast<unsigned>(mData[5]),
+        static_cast<unsigned>(mData[6]),
+        static_cast<unsigned>(mData[7]),
+        static_cast<unsigned>(mData[8]),
+        static_cast<unsigned>(mData[9]),
+        static_cast<unsigned>(mData[10]),
+        static_cast<unsigned>(mData[11]),
+        static_cast<unsigned>(mData[12]),
+        static_cast<unsigned>(mData[13]),
+        static_cast<unsigned>(mData[14]),
+        static_cast<unsigned>(mData[15])
+    );
     return AString(str, str + 36);
 }
 
 AString AUuid::toRawString() const {
     char str[40];
-    sprintf(str,
-            "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
-            mData[0],
-            mData[1],
-            mData[2],
-            mData[3],
-            mData[4],
-            mData[5],
-            mData[6],
-            mData[7],
-            mData[8],
-            mData[9],
-            mData[10],
-            mData[11],
-            mData[12],
-            mData[13],
-            mData[14],
-            mData[15]
+    std::snprintf(str, sizeof(str),
+        "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+        static_cast<unsigned>(mData[0]),
+        static_cast<unsigned>(mData[1]),
+        static_cast<unsigned>(mData[2]),
+        static_cast<unsigned>(mData[3]),
+        static_cast<unsigned>(mData[4]),
+        static_cast<unsigned>(mData[5]),
+        static_cast<unsigned>(mData[6]),
+        static_cast<unsigned>(mData[7]),
+        static_cast<unsigned>(mData[8]),
+        static_cast<unsigned>(mData[9]),
+        static_cast<unsigned>(mData[10]),
+        static_cast<unsigned>(mData[11]),
+        static_cast<unsigned>(mData[12]),
+        static_cast<unsigned>(mData[13]),
+        static_cast<unsigned>(mData[14]),
+        static_cast<unsigned>(mData[15])
     );
     return AString(str, str + 32);
 }

--- a/aui.network/src/AUI/Network/AInet4Address.cpp
+++ b/aui.network/src/AUI/Network/AInet4Address.cpp
@@ -115,7 +115,13 @@ bool AInet4Address::operator<(const AInet4Address& r) const {
 AString AInet4Address::toString() const {
 	uint8_t* bytes = (uint8_t*)&mAddr;
 	char buf[32];
-	sprintf(buf, "%d.%d.%d.%d:%d", bytes[0], bytes[1], bytes[2], bytes[3], mPort);
+	std::snprintf(buf, sizeof(buf), "%u.%u.%u.%u:%u",
+		static_cast<unsigned>(bytes[0]),
+		static_cast<unsigned>(bytes[1]),
+		static_cast<unsigned>(bytes[2]),
+		static_cast<unsigned>(bytes[3]),
+		static_cast<unsigned>(mPort)
+	);
 	return buf;
 }
 

--- a/aui.toolbox/src/Command/Pack.cpp
+++ b/aui.toolbox/src/Command/Pack.cpp
@@ -126,7 +126,7 @@ void Pack::doPacking(const AString& inputFile, const AString& assetPath, const A
         out << "{";
         for (uint8_t c : packed) {
             char buf[32];
-            sprintf(buf, "0x%02x,", c);
+            std::snprintf(buf, sizeof(buf), "0x%02x,", static_cast<unsigned>(c));
             out << std::string(buf);
         }
         out << "};\n";
@@ -134,7 +134,7 @@ void Pack::doPacking(const AString& inputFile, const AString& assetPath, const A
         out << "\"";
         for (uint8_t c : packed) {
             char buf[32];
-            sprintf(buf, "\\x%02x", c);
+            std::snprintf(buf, sizeof(buf), "\\x%02x", static_cast<unsigned>(c));
             out << std::string(buf);
         }
         out << "\";\n";


### PR DESCRIPTION
Silence `sprintf` deprecation warnings.