### PR TITLE
aui.build.cmake: `--strip-all` to silence `-s` warning of `apple`

### DIFF
--- a/cmake/aui.build.cmake
+++ b/cmake/aui.build.cmake
@@ -1722,8 +1722,13 @@ endmacro()
 
 if (MINGW OR UNIX)
     # strip for release
-    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -s")
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
+    if(APPLE)
+        set(CMAKE_EXE_LINKER_FLAGS_RELEASE "-Xlinker --strip-all")
+        set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL "-Xlinker --strip-all")
+    else()
+	    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -s")
+	    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
+    endif()
 endif()
 
 

--- a/cmake/aui.build.cmake
+++ b/cmake/aui.build.cmake
@@ -1119,6 +1119,17 @@ function(aui_module AUI_MODULE_NAME)
             endif()
         endif()
     endif()
+    if (CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")
+        add_custom_command(
+            TARGET ${AUI_MODULE_NAME}
+            POST_BUILD
+            COMMAND $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:${CMAKE_STRIP}>
+            ARGS    $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:-x>
+                    $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:$<TARGET_FILE:${AUI_MODULE_NAME}>>
+            COMMENT "Stripping ${AUI_MODULE_NAME} (only for Release/MinSizeRel)"
+            VERBATIM
+        )
+    endif()
 endfunction(aui_module)
 
 # links the auisl shader located in shaders/<NAME>
@@ -1722,12 +1733,11 @@ endmacro()
 
 if (MINGW OR UNIX)
     # strip for release
-    if(APPLE)
-        set(CMAKE_EXE_LINKER_FLAGS_RELEASE "-Xlinker --strip-all")
-        set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL "-Xlinker --strip-all")
-    else()
+    if (NOT(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang"))
 	    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -s")
 	    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
+        set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL} -s")
+        set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} -s")
     endif()
 endif()
 


### PR DESCRIPTION
Silence a lot of `-s` unused warnings for MacOS builds.