### PR TITLE
Silence clang/ide pragma warnings

### DIFF
--- a/aui.core/src/AUI/Thread/AThreadPool.cpp
+++ b/aui.core/src/AUI/Thread/AThreadPool.cpp
@@ -39,16 +39,23 @@ void AThreadPool::Worker::iteration(std::unique_lock<std::mutex>& tpLock) {
 }
 
 void AThreadPool::Worker::wait(std::unique_lock<std::mutex>& tpLock) {
+#if defined(__clang__)
 #pragma clang diagnostic push
+#endif
+#if defined(__CLION_IDE__) || defined(__CLION_IDE_)
 #pragma ide diagnostic ignored "ConstantConditionsOC"
+#endif
     if (!mEnabled)
         return;
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif
     mTP.mIdleWorkers += 1;
     assert(tpLock.owns_lock());
 
     mTP.mCV.wait(tpLock);
     mTP.mIdleWorkers -= 1;
+
 }
 
 bool AThreadPool::Worker::processQueue(std::unique_lock<std::mutex>& mutex, AQueue<std::function<void()>>& queue) {

--- a/aui.views/src/AUI/Platform/AWindowBase.h
+++ b/aui.views/src/AUI/Platform/AWindowBase.h
@@ -192,12 +192,18 @@ public:
 
     void onKeyDown(AInput::Key key) override;
 
+#if defined(__clang__)
 #pragma clang diagnostic push
+#endif
+#if defined(__CLION_IDE__) || defined(__CLION_IDE_)
 #pragma ide diagnostic ignored "HidingNonVirtualFunction"
+#endif
     virtual void redraw() {
         AView::redraw();
     }
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif
 
     virtual void focusNextView();
     virtual void flagRedraw();

--- a/aui.views/src/AUI/Platform/linux/gtk/window_manager.cpp
+++ b/aui.views/src/AUI/Platform/linux/gtk/window_manager.cpp
@@ -17,8 +17,12 @@
 
 using namespace aui::gtk4_fake;
 
+#if defined(__clang__)
 #pragma clang diagnostic push
+#endif
+#if defined(__CLION_IDE__) || defined(__CLION_IDE_)
 #pragma ide diagnostic ignored "LocalValueEscapesScope"
+#endif
 void PlatformAbstractionGtk::windowManagerInitNativeWindow(const IRenderingContext::Init& init) {
     auto window = GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(*mApplication)));
     windowManagerInitCommon(init, window);
@@ -83,7 +87,9 @@ GtkWidget* PlatformAbstractionGtk::windowManagerInitGtkBox(const IRenderingConte
     }
     return box;
 }
+#if defined(__clang__)
 #pragma clang diagnostic pop
+#endif
 
 void PlatformAbstractionGtk::windowManagerNotifyProcessMessages() {
     g_main_context_wakeup(mMainContext);


### PR DESCRIPTION
Silence unexisting pragma warnings, as for example MSVC.