### PR TITLE
Silence ignored type attribute for mingw

### DIFF
--- a/aui.core/src/AUI/Common/detail/property.h
+++ b/aui.core/src/AUI/Common/detail/property.h
@@ -112,7 +112,7 @@ struct PropertyReadWriteProjection: PropertyReadProjection {
         this->wrappedProperty.notify();
     }
 private:
-    friend class API_AUI_CORE ::AObject;
+    friend class ::AObject;
 
     /**
      * @brief Makes a callable that assigns value to this property.


### PR DESCRIPTION
Silence warning of ignored attribute:
```
[471/583] C:\msys64\mingw64\bin\x86_64-w64-mingw32-g++.exe -DAPI_AUI_CORE=AUI_IMPORT -DAPI_AUI_IMAGE=AUI_IMPORT -DAPI_AUI_VIEWS=AUI_EXPORT -DAPI_AUI_XML=AUI_IMPORT -DAUI_ARCH_ARM_64=0 -DAUI_ARCH_ARM_V7=0 -DAUI_ARCH_X86=0 -DAUI_ARCH_X86_64=1 -DAUI_CATCH_UNHANDLED=1 -DAUI_CMAKE_PROJECT_VERSION="" -DAUI_COMPILER_CLANG=0 -DAUI_COMPILER_GCC=1 -DAUI_COMPILER_MSVC=0 -DAUI_DEBUG=0 -DAUI_ENABLE_DEATH_TESTS=1 -DAUI_MODULE_NAME=aui.views -DAUI_PLATFORM_ANDROID=0 -DAUI_PLATFORM_APPLE=0 -DAUI_PLATFORM_EMSCRIPTEN=0 -DAUI_PLATFORM_IOS=0 -DAUI_PLATFORM_LINUX=0 -DAUI_PLATFORM_MACOS=0 -DAUI_PLATFORM_UNIX=0 -DAUI_PLATFORM_WIN=1 -DGLM_ENABLE_EXPERIMENTAL=1 -DGLM_FORCE_INLINE=1 -DNOMINMAX=1 -DUNICODE=1 -DWINVER=0x601 -Daui_views_EXPORTS -IC:/Users/Admin/AppData/Local/.xmake/cache/packages/2508/a/aui/v7.1.2/source/aui.views/src -IC:/Users/Admin/AppData/Local/.xmake/cache/packages/2508/a/aui/v7.1.2/source/build_a521519a/aui.views/shaders -IC:/Users/Admin/AppData/Local/.xmake/cache/packages/2508/a/aui/v7.1.2/source/aui.core/src -IC:/Users/Admin/AppData/Local/.xmake/packages/g/glm/1.0.1/ab53ed00a9ff4c85bb2371883c32baba/include -IC:/Users/Admin/AppData/Local/.xmake/cache/packages/2508/a/aui/v7.1.2/source/aui.image/src -IC:/Users/Admin/AppData/Local/.xmake/cache/packages/2508/a/aui/v7.1.2/source/aui.xml/src -isystem C:/Users/Admin/AppData/Local/.xmake/packages/f/fmt/9.1.0/c9b2afe9b0654b679067b2e3ec7e43a7/include -isystem C:/Users/Admin/AppData/Local/.xmake/packages/r/range-v3/0.12.0/13acca86fd02463f9329adc2d640d8ec/include -isystem C:/Users/Admin/AppData/Local/.xmake/packages/f/freetype/2.13.3/192a6f82646c4377bccbd727ebda85ac/include/freetype2 -m64 -DGLEW_NO_GLU -DGLEW_STATIC -IC:/Users/Admin/AppData/Local/.xmake/packages/g/glew/2.2.0/f1937cf4c620461cac69417973f0b9e2/include -IC:/Users/Admin/AppData/Local/.xmake/packages/g/gtest/v1.17.0/c9c4e32023294b2f8ad23076694785ee/include -m64 -DGLEW_NO_GLU -DGLEW_STATIC -IC:/Users/Admin/AppData/Local/.xmake/packages/g/glew/2.2.0/f1937cf4c620461cac69417973f0b9e2/include -IC:/Users/Admin/AppData/Local/.xmake/packages/g/gtest/v1.17.0/c9c4e32023294b2f8ad23076694785ee/include -O3 -DNDEBUG -s -std=gnu++20 -fexceptions -fnon-call-exceptions -MD -MT aui.views/CMakeFiles/aui.views.dir/src/AUI/View/ACircleProgressBar.cpp.obj -MF aui.views\CMakeFiles\aui.views.dir\src\AUI\View\ACircleProgressBar.cpp.obj.d -o aui.views/CMakeFiles/aui.views.dir/src/AUI/View/ACircleProgressBar.cpp.obj -c C:/Users/Admin/AppData/Local/.xmake/cache/packages/2508/a/aui/v7.1.2/source/aui.views/src/AUI/View/ACircleProgressBar.cpp
In file included from C:/Users/Admin/AppData/Local/.xmake/cache/packages/2508/a/aui/v7.1.2/source/aui.core/src/AUI/Common/APropertyPrecomputed.h:17,
                 from C:/Users/Admin/AppData/Local/.xmake/cache/packages/2508/a/aui/v7.1.2/source/aui.core/src/AUI/Common/AProperty.h:15,
                 from C:/Users/Admin/AppData/Local/.xmake/cache/packages/2508/a/aui/v7.1.2/source/aui.views/src/AUI/View/AView.h:49,
                 from C:/Users/Admin/AppData/Local/.xmake/cache/packages/2508/a/aui/v7.1.2/source/aui.views/src/AUI/Util/IBackgroundEffect.h:14,
                 from C:/Users/Admin/AppData/Local/.xmake/cache/packages/2508/a/aui/v7.1.2/source/aui.views/src/AUI/Views.h:17,
                 from C:/Users/Admin/AppData/Local/.xmake/cache/packages/2508/a/aui/v7.1.2/source/aui.views/src/AUI/View/AViewContainerBase.h:14,
                 from C:/Users/Admin/AppData/Local/.xmake/cache/packages/2508/a/aui/v7.1.2/source/aui.views/src/AUI/View/AViewContainer.h:14,
                 from C:/Users/Admin/AppData/Local/.xmake/cache/packages/2508/a/aui/v7.1.2/source/aui.views/src/AUI/View/ACircleProgressBar.h:14,
                 from C:/Users/Admin/AppData/Local/.xmake/cache/packages/2508/a/aui/v7.1.2/source/aui.views/src/AUI/View/ACircleProgressBar.cpp:16:
C:/Users/Admin/AppData/Local/.xmake/cache/packages/2508/a/aui/v7.1.2/source/aui.core/src/AUI/Common/detail/property.h:115:33: warning: type attributes ignored after type is already defined [-Wattributes]
  115 |     friend class API_AUI_CORE ::AObject;
      |                                 ^~~~~~~
```