### PR TITLE
aui.image/CMakeLists.txt: Silence sprintf deprecation for stb/curl dependencies

### DIFF
--- a/aui.curl/CMakeLists.txt
+++ b/aui.curl/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.10)
 
-auib_import(CURL https://github.com/aui-framework/curl/archive/refs/heads/master.zip
+auib_import(CURL https://github.com/aui-framework/curl/archive/b92149696f1b740b144e52f44c81b25edb2e1b24.zip
             ARCHIVE)
 
 aui_module(aui.curl EXPORT aui WHOLEARCHIVE)

--- a/aui.image/3rdparty/stb_image_write.h
+++ b/aui.image/3rdparty/stb_image_write.h
@@ -772,7 +772,7 @@ static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, f
 
 #ifdef __STDC_LIB_EXT1__
         len = sprintf_s(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
-#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#elif HAVE_SNPRINTF
       len = snprintf(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
 #else
         len = sprintf(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);

--- a/aui.image/3rdparty/stb_image_write.h
+++ b/aui.image/3rdparty/stb_image_write.h
@@ -772,6 +772,8 @@ static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, f
 
 #ifdef __STDC_LIB_EXT1__
         len = sprintf_s(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+      len = snprintf(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
 #else
         len = sprintf(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
 #endif

--- a/aui.image/3rdparty/stb_image_write.h
+++ b/aui.image/3rdparty/stb_image_write.h
@@ -772,7 +772,7 @@ static int stbi_write_hdr_core(stbi__write_context *s, int x, int y, int comp, f
 
 #ifdef __STDC_LIB_EXT1__
         len = sprintf_s(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
-#elif HAVE_SNPRINTF
+#elif defined(HAVE_SNPRINTF)
       len = snprintf(buffer, sizeof(buffer), "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);
 #else
         len = sprintf(buffer, "EXPOSURE=          1.0000000000000\n\n-Y %d +X %d\n", y, x);

--- a/aui.image/CMakeLists.txt
+++ b/aui.image/CMakeLists.txt
@@ -15,6 +15,15 @@ endforeach()
 auib_import(WebP https://github.com/webmproject/libwebp VERSION v1.3.1 CMAKE_ARGS ${WEBP_CMAKE_ARGS})
 
 aui_module(aui.image WHOLEARCHIVE EXPORT aui)
+
+if(NOT MSVC OR (MSVC_VERSION GREATER_EQUAL 1900))
+    include(CheckSymbolExists)
+    check_symbol_exists(snprintf "stdio.h" HAVE_SNPRINTF)
+    if(HAVE_SNPRINTF)
+        target_compile_definitions(aui.image PUBLIC HAVE_SNPRINTF=1)
+    endif()
+endif()
+
 add_subdirectory(3rdparty)
 aui_link(aui.image PRIVATE aui::core lunasvg::lunasvg WebP::webp WebP::webpdemux)
 aui_enable_tests(aui.image)

--- a/aui.image/CMakeLists.txt
+++ b/aui.image/CMakeLists.txt
@@ -15,26 +15,6 @@ endforeach()
 auib_import(WebP https://github.com/webmproject/libwebp VERSION v1.3.1 CMAKE_ARGS ${WEBP_CMAKE_ARGS})
 
 aui_module(aui.image WHOLEARCHIVE EXPORT aui)
-
-# Wait for https://github.com/nothings/stb/pull/1619 being merged
-file(READ "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/stb_image_write.h" FILE_CONTENT)
-set(OLD_SPRINTF_STRING
-"#ifdef __STDC_LIB_EXT1__\n\
-        len = sprintf_s(buffer, sizeof(buffer), \"EXPOSURE=          1.0000000000000\\n\\n-Y %d +X %d\\n\", y, x);\n\
-#else\n\
-        len = sprintf(buffer, \"EXPOSURE=          1.0000000000000\\n\\n-Y %d +X %d\\n\", y, x);\n\
-#endif")
-set(NEW_SPRINTF_STRING
-"#ifdef __STDC_LIB_EXT1__\n\
-        len = sprintf_s(buffer, sizeof(buffer), \"EXPOSURE=          1.0000000000000\\n\\n-Y %d +X %d\\n\", y, x);\n\
-#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L\n\
-        len = snprintf(buffer, sizeof(buffer), \"EXPOSURE=          1.0000000000000\\n\\n-Y %d +X %d\\n\", y, x);\n\
-#else\n\
-        len = sprintf(buffer, \"EXPOSURE=          1.0000000000000\\n\\n-Y %d +X %d\\n\", y, x);\n\
-#endif")
-string(REPLACE "${OLD_SPRINTF_STRING}" "${NEW_SPRINTF_STRING}" FILE_CONTENT "${FILE_CONTENT}")
-file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/stb_image_write.h" "${FILE_CONTENT}")
-
 add_subdirectory(3rdparty)
 aui_link(aui.image PRIVATE aui::core lunasvg::lunasvg WebP::webp WebP::webpdemux)
 aui_enable_tests(aui.image)

--- a/aui.image/CMakeLists.txt
+++ b/aui.image/CMakeLists.txt
@@ -15,6 +15,26 @@ endforeach()
 auib_import(WebP https://github.com/webmproject/libwebp VERSION v1.3.1 CMAKE_ARGS ${WEBP_CMAKE_ARGS})
 
 aui_module(aui.image WHOLEARCHIVE EXPORT aui)
+
+# Wait for https://github.com/nothings/stb/pull/1619 being merged
+file(READ "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/stb_image_write.h" FILE_CONTENT)
+set(OLD_SPRINTF_STRING
+"#ifdef __STDC_LIB_EXT1__\n\
+        len = sprintf_s(buffer, sizeof(buffer), \"EXPOSURE=          1.0000000000000\\n\\n-Y %d +X %d\\n\", y, x);\n\
+#else\n\
+        len = sprintf(buffer, \"EXPOSURE=          1.0000000000000\\n\\n-Y %d +X %d\\n\", y, x);\n\
+#endif")
+set(NEW_SPRINTF_STRING
+"#ifdef __STDC_LIB_EXT1__\n\
+        len = sprintf_s(buffer, sizeof(buffer), \"EXPOSURE=          1.0000000000000\\n\\n-Y %d +X %d\\n\", y, x);\n\
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 199901L\n\
+        len = snprintf(buffer, sizeof(buffer), \"EXPOSURE=          1.0000000000000\\n\\n-Y %d +X %d\\n\", y, x);\n\
+#else\n\
+        len = sprintf(buffer, \"EXPOSURE=          1.0000000000000\\n\\n-Y %d +X %d\\n\", y, x);\n\
+#endif")
+string(REPLACE "${OLD_SPRINTF_STRING}" "${NEW_SPRINTF_STRING}" FILE_CONTENT "${FILE_CONTENT}")
+file(WRITE "${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/stb_image_write.h" "${FILE_CONTENT}")
+
 add_subdirectory(3rdparty)
 aui_link(aui.image PRIVATE aui::core lunasvg::lunasvg WebP::webp WebP::webpdemux)
 aui_enable_tests(aui.image)


### PR DESCRIPTION
Maybe better to just edit bundled dependency directly without patching.
Alas, curl has same issue https://github.com/aui-framework/curl/pull/2