### PR TITLE
Silence receiver type 'void *' is not 'id' & API_DEPRECATED_WITH_REPLACEMENT("NSOpenGLContextParameterSwapInterval")

### DIFF
--- a/aui.views/src/AUI/Platform/macos/OpenGLRenderingContextImpl.mm
+++ b/aui.views/src/AUI/Platform/macos/OpenGLRenderingContextImpl.mm
@@ -72,9 +72,9 @@ void OpenGLRenderingContext::init(const Init& init) {
 
     auto contentView  = [static_cast<NSWindow*>(window.mHandle) contentView];
     [contentView setWantsBestResolutionOpenGLSurface:YES];
-    [ourContext setView:contentView];
+    [static_cast<NSOpenGLContext*>(ourContext) setView:contentView];
 
-    [ourContext makeCurrentContext];
+    [static_cast<NSOpenGLContext*>(ourContext) makeCurrentContext];
 
     GLint stencilBits = 0;
     glGetIntegerv(GL_STENCIL_BITS, &stencilBits);
@@ -97,7 +97,7 @@ void OpenGLRenderingContext::beginPaint(AWindowBase& window) {
     CommonRenderingContext::beginPaint(window);
     if (auto nativeWindow = dynamic_cast<AWindow*>(&window)) {
         auto contentView  = [static_cast<NSWindow*>(nativeWindow->mHandle) contentView];
-        [ourContext setView:contentView];
+        [static_cast<NSOpenGLContext*>(ourContext) setView:contentView];
     }
 
     beginFramebuffer(window.getSize());
@@ -109,10 +109,10 @@ void OpenGLRenderingContext::beginResize(AWindowBase& window) {
     [static_cast<NSOpenGLContext*>(ourContext) makeCurrentContext];
     if (auto nativeWindow = dynamic_cast<AWindow*>(&window)) {
         auto contentView  = [static_cast<NSWindow*>(nativeWindow->mHandle) contentView];
-        [ourContext setView:contentView];
+        [static_cast<NSOpenGLContext*>(ourContext) setView:contentView];
     }
     GLint swapInterval = 0;
-    [static_cast<NSOpenGLContext*>(ourContext) setValues:&swapInterval forParameter:NSOpenGLCPSwapInterval];
+    [static_cast<NSOpenGLContext*>(ourContext) setValues:&swapInterval forParameter:NSOpenGLContextParameterSwapInterval];
 }
 
 void OpenGLRenderingContext::endResize(AWindowBase& window) {


### PR DESCRIPTION
Silence receiver type 'void *' is not 'id' or interface pointer, consider casting it to 'id' & `static const NSOpenGLContextParameter NSOpenGLCPSwapInterval API_DEPRECATED_WITH_REPLACEMENT("NSOpenGLContextParameterSwapInterval", macos(10.5,10.14)) = NSOpenGLContextParameterSwapInterval;`
```
2025-08-13T06:31:11.8526980Z /Users/runner/work/aui/aui/aui.views/src/AUI/Platform/macos/OpenGLRenderingContextImpl.mm:75:6: warning: receiver type 'void *' is not 'id' or interface pointer, consider casting it to 'id' [-Wreceiver-expr]
2025-08-13T06:31:11.8627660Z    75 |     [ourContext setView:contentView];
2025-08-13T06:31:11.8728620Z       |      ^~~~~~~~~~
2025-08-13T06:31:11.8829420Z /Users/runner/work/aui/aui/aui.views/src/AUI/Platform/macos/OpenGLRenderingContextImpl.mm:77:6: warning: receiver type 'void *' is not 'id' or interface pointer, consider casting it to 'id' [-Wreceiver-expr]
2025-08-13T06:31:11.8929420Z    77 |     [ourContext makeCurrentContext];
2025-08-13T06:31:11.9029930Z       |      ^~~~~~~~~~
2025-08-13T06:31:11.9131030Z /Users/runner/work/aui/aui/aui.views/src/AUI/Platform/macos/OpenGLRenderingContextImpl.mm:100:10: warning: receiver type 'void *' is not 'id' or interface pointer, consider casting it to 'id' [-Wreceiver-expr]
2025-08-13T06:31:11.9231250Z   100 |         [ourContext setView:contentView];
2025-08-13T06:31:11.9436600Z       |          ^~~~~~~~~~
2025-08-13T06:31:11.9437410Z /Users/runner/work/aui/aui/aui.views/src/AUI/Platform/macos/OpenGLRenderingContextImpl.mm:112:10: warning: receiver type 'void *' is not 'id' or interface pointer, consider casting it to 'id' [-Wreceiver-expr]
2025-08-13T06:31:11.9538780Z   112 |         [ourContext setView:contentView];
2025-08-13T06:31:11.9639680Z       |          ^~~~~~~~~~
2025-08-13T06:31:11.9741090Z /Users/runner/work/aui/aui/aui.views/src/AUI/Platform/macos/OpenGLRenderingContextImpl.mm:115:85: warning: 'NSOpenGLCPSwapInterval' is deprecated: first deprecated in macOS 10.14 [-Wdeprecated-declarations]
2025-08-13T06:31:11.9842750Z   115 |     [static_cast<NSOpenGLContext*>(ourContext) setValues:&swapInterval forParameter:NSOpenGLCPSwapInterval];
2025-08-13T06:31:11.9943990Z       |                                                                                     ^~~~~~~~~~~~~~~~~~~~~~
2025-08-13T06:31:12.0045120Z       |                                                                                     NSOpenGLContextParameterSwapInterval
2025-08-13T06:31:12.0147500Z /Applications/Xcode_16.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.0.sdk/System/Library/Frameworks/AppKit.framework/Headers/NSOpenGL.h:258:39: note: 'NSOpenGLCPSwapInterval' has been explicitly marked deprecated here
2025-08-13T06:31:12.0249570Z   258 | static const NSOpenGLContextParameter NSOpenGLCPSwapInterval API_DEPRECATED_WITH_REPLACEMENT("NSOpenGLContextParameterSwapInterval", macos(10.5,10.14)) = NSOpenGLContextParameterSwapInterval;
2025-08-13T06:31:12.0351000Z       |                                       ^
2025-08-13T06:31:12.0395950Z 5 warnings generated.
```