### PR TITLE
Silence clang++: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument] Use `llvm-strip`

### DIFF
--- a/cmake/aui.build.cmake
+++ b/cmake/aui.build.cmake
@@ -1130,6 +1130,29 @@ function(aui_module AUI_MODULE_NAME)
             COMMENT "Stripping ${AUI_MODULE_NAME} (only for Release/MinSizeRel)"
             VERBATIM
         )
+    elseif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+        if(APPLE)
+            add_custom_command(
+                TARGET ${AUI_MODULE_NAME}
+                POST_BUILD
+                COMMAND $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:${CMAKE_STRIP}>
+                ARGS    $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:-Sxl>
+                        $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:$<TARGET_FILE:${AUI_MODULE_NAME}>>
+                COMMENT "Stripping ${AUI_MODULE_NAME} (only for Release/MinSizeRel)"
+                VERBATIM
+            )
+        else()
+            add_custom_command(
+                TARGET ${AUI_MODULE_NAME}
+                POST_BUILD
+                COMMAND $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:${CMAKE_STRIP}>
+                ARGS    $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:-g>
+                        $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:-x>
+                        $<$<OR:$<CONFIG:Release>,$<CONFIG:MinSizeRel>>:$<TARGET_FILE:${AUI_MODULE_NAME}>>
+                COMMENT "Stripping ${AUI_MODULE_NAME} (only for Release/MinSizeRel)"
+                VERBATIM
+            )
+        endif()
     endif()
 endfunction(aui_module)
 
@@ -1734,7 +1757,7 @@ endmacro()
 
 if (MINGW OR UNIX)
     # strip for release
-    if (NOT(CMAKE_CXX_COMPILER_ID MATCHES "AppleClang"))
+    if (NOT(CMAKE_CXX_COMPILER_ID MATCHES "(AppleClang|Clang)"))
 	    set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -s")
 	    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -s")
         set(CMAKE_C_FLAGS_MINSIZEREL "${CMAKE_C_FLAGS_MINSIZEREL} -s")


### PR DESCRIPTION
Continue of https://github.com/aui-framework/aui/pull/545

CC: @Alex2772 

Linux Clang warnings experience currently:
<img width="152" height="23" alt="{2661FEB3-7781-4B5A-B6BF-140FDDDA7EFA}" src="https://github.com/user-attachments/assets/756c1808-03a8-42aa-882a-7208e9414ded" />

Silence clang++: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument] Use `llvm-strip`.

```
2025-08-13T12:44:00.0731961Z -- Cleaning up build directory
2025-08-13T12:44:00.0732673Z -- Imported: ctre (ctre::ctre) (/home/runner/.aui/prefix/ctre/ad27531f25e0925da04e85e3e7ea2bae) (version v3.9.0)
2025-08-13T12:44:00.1001823Z -- [AUI.BOOT] Output precompiled archive name: aui_linux-clang-x86_64-static-release
2025-08-13T12:44:00.1171759Z -- Configuring done (11.8s)
2025-08-13T12:44:00.2607696Z -- Generating done (0.1s)
2025-08-13T12:44:00.2616542Z -- Build files have been written to: /home/runner/work/aui/aui/build
2025-08-13T12:44:00.2787026Z ##[group]Run cmake --build /home/runner/work/aui/aui/build --config Release
2025-08-13T12:44:00.2787896Z [36;1mcmake --build /home/runner/work/aui/aui/build --config Release[0m
2025-08-13T12:44:00.2834545Z shell: /usr/bin/bash -e {0}
2025-08-13T12:44:00.2834777Z env:
2025-08-13T12:44:00.2834961Z   GIT_SUBMODULE_STRATEGY: recursive
2025-08-13T12:44:00.2835212Z   CC: /usr/bin/clang 
2025-08-13T12:44:00.2835428Z   CXX: /usr/bin/clang++ 
2025-08-13T12:44:00.2835621Z ##[endgroup]
2025-08-13T12:44:03.8906713Z [1/126] Building CXX object aui.audio/CMakeFiles/aui.audio.dir/src/AUI/Audio/AGainFilter.cpp.o
2025-08-13T12:44:03.8911915Z clang++: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:05.7194366Z [2/126] Building CXX object aui.audio/CMakeFiles/aui.audio.dir/src/AUI/Audio/AAudioFormat.cpp.o
2025-08-13T12:44:05.7199278Z clang++: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:08.8231387Z [3/126] Building CXX object aui.audio/CMakeFiles/aui.audio.dir/src/AUI/Audio/Formats/opus/AOpusSoundPipe.cpp.o
2025-08-13T12:44:08.8232842Z clang++: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:09.6587658Z [4/126] Building CXX object aui.audio/CMakeFiles/aui.audio.dir/src/AUI/Audio/AAudioResampler.cpp.o
2025-08-13T12:44:09.6589323Z clang++: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:10.6581360Z [5/126] Building CXX object aui.audio/CMakeFiles/aui.audio.dir/src/AUI/Audio/AAudioMixer.cpp.o
2025-08-13T12:44:10.6613490Z clang++: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:11.2180465Z [6/126] Building CXX object aui.audio/CMakeFiles/aui.audio.dir/src/AUI/Audio/Formats/raw/ARawSoundStream.cpp.o
2025-08-13T12:44:11.2182155Z clang++: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:13.3973520Z [7/126] Building CXX object aui.audio/CMakeFiles/aui.audio.dir/src/AUI/Audio/Formats/ogg/AOggSoundStream.cpp.o
2025-08-13T12:44:13.3978849Z clang++: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:15.0728686Z [8/126] Building CXX object aui.audio/CMakeFiles/aui.audio.dir/src/AUI/Audio/Formats/vorbis/AVorbisSoundPipe.cpp.o
2025-08-13T12:44:15.0741941Z clang++: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:16.8184606Z [9/126] Building CXX object aui.audio/CMakeFiles/aui.audio.dir/src/AUI/Audio/Formats/wav/AWavSoundStream.cpp.o
2025-08-13T12:44:16.8189987Z clang++: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:17.0736623Z [10/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/analysis.c.o
2025-08-13T12:44:17.0741946Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:17.1244106Z [11/126] Building CXX object aui.audio/CMakeFiles/aui.audio.dir/src/AUI/Audio/SincResampler.cpp.o
2025-08-13T12:44:17.1254021Z clang++: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:17.3049696Z [12/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/bitrate.c.o
2025-08-13T12:44:17.3083427Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:17.4297709Z [13/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/bitwise.c.o
2025-08-13T12:44:17.4298818Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:17.8137764Z [14/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/codebook.c.o
2025-08-13T12:44:17.8139152Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:18.1746296Z [15/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/envelope.c.o
2025-08-13T12:44:18.1747882Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:18.1876466Z [16/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/block.c.o
2025-08-13T12:44:18.1893709Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:18.4238955Z [17/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/floor0.c.o
2025-08-13T12:44:18.4240243Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:18.8675245Z [18/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/floor1.c.o
2025-08-13T12:44:18.8680381Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:18.8757919Z [19/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/framing.c.o
2025-08-13T12:44:18.8759353Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:19.0889341Z [20/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/lookup.c.o
2025-08-13T12:44:19.0900922Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:19.3275980Z [21/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/info.c.o
2025-08-13T12:44:19.3278744Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:19.4003063Z [22/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/lpc.c.o
2025-08-13T12:44:19.4008273Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:19.7181762Z [23/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/lsp.c.o
2025-08-13T12:44:19.7188234Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:19.8173850Z [24/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/mapping0.c.o
2025-08-13T12:44:19.8179252Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:20.4437833Z [25/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/mdct.c.o
2025-08-13T12:44:20.4443057Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:20.5162678Z [26/126] Building CXX object aui.audio/CMakeFiles/aui.audio.dir/src/AUI/Audio/Platform/linux/PulseAudioPlayer.cpp.o
2025-08-13T12:44:20.5167777Z clang++: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:20.5555522Z [27/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/registry.c.o
2025-08-13T12:44:20.5560351Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:20.9620168Z [28/126] Building CXX object aui.audio/CMakeFiles/aui.audio.dir/src/AUI/Audio/Platform/IAudioPlayer.cpp.o
2025-08-13T12:44:20.9624964Z clang++: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:21.0073208Z [29/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/sharedbook.c.o
2025-08-13T12:44:21.0078176Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:21.1436614Z [30/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/psy.c.o
2025-08-13T12:44:21.1441648Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:21.1805457Z [31/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/synthesis.c.o
2025-08-13T12:44:21.1806786Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:21.3323671Z [32/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/res0.c.o
2025-08-13T12:44:21.3328643Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
2025-08-13T12:44:21.5678053Z [33/126] Building C object aui.audio/CMakeFiles/aui.audio.dir/3rdparty/ogg/src/window.c.o
2025-08-13T12:44:21.5693695Z clang: warning: argument unused during compilation: '-s' [-Wunused-command-line-argument]
```