### PR TITLE
aui.core/ProcessTest.cpp: Silence deprecation `AProcess::executeWaitForExit`

### DIFF
--- a/aui.core/tests/ProcessTest.cpp
+++ b/aui.core/tests/ProcessTest.cpp
@@ -62,7 +62,10 @@ TEST_F(ProcessTest, Self) {
 }
 
 TEST_F(ProcessTest, ExitCode) {
-    auto process = AProcess::make(mSelf, "--help");
+    auto process = AProcess::create({
+        .executable = mSelf,
+        .args = AProcess::ArgStringList { { "--help"} },
+    });
     process->run();
     EXPECT_EQ(process->waitForExitCode(), 0);
 }

--- a/aui.core/tests/ProcessTest.cpp
+++ b/aui.core/tests/ProcessTest.cpp
@@ -62,7 +62,9 @@ TEST_F(ProcessTest, Self) {
 }
 
 TEST_F(ProcessTest, ExitCode) {
-    EXPECT_EQ(AProcess::executeWaitForExit(mSelf, "--help"), 0);
+    auto process = AProcess::make(mSelf, "--help");
+    process->run();
+    EXPECT_EQ(process->waitForExitCode(), 0);
 }
 
 TEST_F(ProcessTest, Stdout) {


### PR DESCRIPTION
aui.core/ProcessTest.cpp: Silence deprecation `AProcess::executeWaitForExit`

```
2025-08-13T23:33:55.8480320Z [15/148] Building CXX object aui.core/CMakeFiles/Tests.dir/tests/ProcessTest.cpp.o
2025-08-13T23:33:55.8583420Z /Users/runner/work/aui/aui/aui.core/tests/ProcessTest.cpp:65:25: warning: 'executeWaitForExit' is deprecated: use auto process = AProcess::make(); process->run(); process->waitForExitCode() [-Wdeprecated-declarations]
2025-08-13T23:33:55.8683700Z    65 |     EXPECT_EQ(AProcess::executeWaitForExit(mSelf, "--help"), 0);
2025-08-13T23:33:55.8784690Z       |                         ^
2025-08-13T23:33:55.8887080Z /Users/runner/work/aui/aui/aui.core/src/AUI/Platform/AProcess.h:216:7: note: 'executeWaitForExit' has been explicitly marked deprecated here
2025-08-13T23:33:55.8987660Z   216 |     [[deprecated("use auto process = AProcess::make(); process->run(); process->waitForExitCode()")]]
2025-08-13T23:33:55.9089000Z       |       ^
2025-08-13T23:33:55.9189200Z 1 warning generated.
```