### PR TITLE
Do not use `/MP` when using `clang-cl.exe` compiler

### DIFF
--- a/aui.boot.cmake
+++ b/aui.boot.cmake
@@ -906,11 +906,10 @@ function(auib_import AUI_MODULE_NAME URL)
                     endif()
                 endforeach()
 
-
-                if(MSVC)
-                    # force msvc compiler to parallel build
-                    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
-                    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+ 
+                # force msvc compiler to parallel build
+                if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")                           # MSVC but exclude clang-cl
+                    set_property(DIRECTORY APPEND PROPERTY COMPILE_OPTIONS "-MP")   # Parallel compilation
                 endif()
 
                 if (IOS)

--- a/cmake/aui.build.cmake
+++ b/cmake/aui.build.cmake
@@ -204,9 +204,15 @@ endif()
 
 function(aui_add_properties AUI_MODULE_NAME)
     if(MSVC)
-        set_target_properties(${AUI_MODULE_NAME} PROPERTIES
-                LINK_FLAGS "/force:MULTIPLE"
-                COMPILE_FLAGS "/MP /utf-8")
+        if(CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+            set_target_properties(${AUI_MODULE_NAME} PROPERTIES
+                    LINK_FLAGS "/force:MULTIPLE"
+                    COMPILE_FLAGS "/MP /utf-8")
+        else() # clang-cl does not support /MP
+            set_target_properties(${AUI_MODULE_NAME} PROPERTIES
+                    LINK_FLAGS "/force:MULTIPLE"
+                    COMPILE_FLAGS "/utf-8")
+        endif()
     endif()
 
     if(NOT ANDROID)


### PR DESCRIPTION
Do not use `/MP` when using `clang-cl.exe` compiler.
Guard `/MP` for `clang-cl.exe` and `cl.exe`.