### PR TITLE
Potential Vulnerability in Cloned Code

### DIFF
--- a/aui.image/3rdparty/gifdec.h
+++ b/aui.image/3rdparty/gifdec.h
@@ -440,7 +440,7 @@ read_image_data(gd_GIF *gif, int interlace)
             if (interlace)
                 y = interlaced_line_index((int) gif->fh, y);
             gif->frame[(gif->fy + y) * gif->width + gif->fx + x] = entry.suffix;
-            if (entry.prefix == 0xFFF)
+            if (entry.prefix == 0xFFF || entry.prefix >= table->nentries)
                 break;
             else
                 entry = table->entries[entry.prefix];


### PR DESCRIPTION
### Summary
Our tool detected a potential vulnerability in aui.image/3rdparty/gifdec.h which was cloned from lecram/gifdec but did not receive the security patch applied. The original issue was reported and fixed under https://nvd.nist.gov/vuln/detail/CVE-2022-43359.

### Proposed Fix
Apply the same patch as the one in lecram/gifdec to eliminate the vulnerability.

### Reference
https://nvd.nist.gov/vuln/detail/CVE-2022-43359
https://github.com/lecram/gifdec/commit/970558212348b60359f967a5d999078b6f9efe04