### PR TITLE
workaround freetype with cmake 4.0

### DIFF
--- a/aui.core/src/AUI/Thread/AFuture.h
+++ b/aui.core/src/AUI/Thread/AFuture.h
@@ -33,7 +33,7 @@
 #include <AUI/Traits/concepts.h>
 #include <AUI/Util/ABitField.h>
 
-class API_AUI_CORE AThreadPool;
+class AThreadPool;
 
 
 class AInvocationTargetException: public AException {

--- a/aui.views/CMakeLists.txt
+++ b/aui.views/CMakeLists.txt
@@ -12,6 +12,9 @@ if (OPENGL_FOUND OR ANDROID OR IOS)
     if(AUIB_DISABLE)
         find_package(freetype REQUIRED CONFIG)
     else()
+        # Freetype 2.14.1 fails to build with recent CMake versions due to policy issues.
+        # Setting CMAKE_POLICY_VERSION_MINIMUM to 3.5 is a workaround.
+        # See also: https://github.com/aui-framework/aui/pull/687
         auib_import(Freetype https://github.com/freetype/freetype/archive/refs/tags/VER-2-14-1.zip ARCHIVE
                     CONFIG_ONLY
                     CMAKE_ARGS

--- a/aui.views/CMakeLists.txt
+++ b/aui.views/CMakeLists.txt
@@ -14,7 +14,12 @@ if (OPENGL_FOUND OR ANDROID OR IOS)
     else()
         auib_import(Freetype https://github.com/freetype/freetype/archive/refs/tags/VER-2-14-1.zip ARCHIVE
                     CONFIG_ONLY
-                    CMAKE_ARGS -DFT_DISABLE_BZIP2=ON -DFT_DISABLE_PNG=ON -DFT_DISABLE_HARFBUZZ=ON -DFT_DISABLE_BROTLI=ON
+                    CMAKE_ARGS
+                      -DFT_DISABLE_BZIP2=ON
+                      -DFT_DISABLE_PNG=ON
+                      -DFT_DISABLE_HARFBUZZ=ON
+                      -DFT_DISABLE_BROTLI=ON
+                      -DCMAKE_POLICY_VERSION_MINIMUM=3.5
         )
     endif()
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ from conan.tools.cmake import CMakeToolchain, CMake, cmake_layout, CMakeDeps
 
 class AUIRecipe(ConanFile):
     name = "aui"
-    version = "1.0"
+    version = "8.0.0"
 
     # Optional metadata
     license = "MPL2"
@@ -75,7 +75,7 @@ class AUIRecipe(ConanFile):
         self.requires("lunasvg/3.0.1")
         self.requires("libwebp/1.5.0")
         # Views
-        self.requires("freetype/2.13.3")
+        self.requires("freetype/2.14.1")
         if str(self.settings.os) in {"Windows", "Linux", "Macos"}:
             self.requires("glew/2.2.0")
 


### PR DESCRIPTION
added a dirty hack but it seems to work fine.

freetype won't compile without this on cmake 4.0+ which is annoying af.