### PR TITLE
Fixed MSVC runtime library on clang, fixed aui_entry and bump ctre version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -225,7 +225,7 @@ jobs:
             shared_or_static: static
             arch: x86_64
             generator: "Ninja"
-            additional_cmake_flags: '-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreadedDebug'
+            additional_cmake_flags: '-DCMAKE_MSVC_RUNTIME_LIBRARY=MultiThreaded'
 
           - os: windows-11-arm
             compiler: "Default"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -314,7 +314,7 @@ jobs:
         run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}} --target Tests
 
       - name: Run AUI tests (Windows)
-        if: runner.os == 'Windows' && matrix.generator == 'Ninja' && matrix.build_type != 'Release' && runner.arch != 'ARM64'
+        if: runner.os == 'Windows' && matrix.generator == 'Ninja' && matrix.build_type == 'Debug' && runner.arch != 'ARM64'
         working-directory: ${{github.workspace}}/build/bin
         run: ${{github.workspace}}/build/bin/Tests.exe
 

--- a/aui.core/src/AUI/Platform/Entry.h
+++ b/aui.core/src/AUI/Platform/Entry.h
@@ -65,7 +65,7 @@
     static int fake_main(int argc, char** argv) {                               \
         return aui_main(argc, argv, aui_entry);\
     }             \
-AUI_EXPORT int aui_entry(const AStringVector& args)
+[[maybe_unused]] static int _fake_aui_entry(const AStringVector& args)
 #else
     #define AUI_ENTRY \
     AUI_EXPORT int aui_entry(const AStringVector& args); \
@@ -108,7 +108,7 @@ JNI_OnLoad(JavaVM* vm, void* reserved) { \
     static int fake_main(int argc, char** argv) {                               \
         return aui_main(argc, argv, aui_entry);\
     } \
-    AUI_EXPORT static int aui_entry(const AStringVector& args)
+[[maybe_unused]] static int _fake_aui_entry(const AStringVector& args)
 #else
 #define AUI_ENTRY \
     AUI_EXPORT int aui_entry(const AStringVector& args); \

--- a/aui.core/src/AUI/Platform/Entry.h
+++ b/aui.core/src/AUI/Platform/Entry.h
@@ -62,9 +62,6 @@
 #define AUI_ENTRY \
     AUI_EXPORT int aui_entry(const AStringVector& args); \
     AUI_EXPORT int aui_main(int argc, char** argv, int(*aui_entry)(const AStringVector&)); \
-    static int fake_main(int argc, char** argv) {                               \
-        return aui_main(argc, argv, aui_entry);\
-    }             \
 [[maybe_unused]] static int _fake_aui_entry(const AStringVector& args)
 #else
     #define AUI_ENTRY \
@@ -105,9 +102,6 @@ JNI_OnLoad(JavaVM* vm, void* reserved) { \
 #define AUI_ENTRY \
     AUI_EXPORT static int aui_entry(const AStringVector& args); \
     AUI_EXPORT int aui_main(int argc, char** argv, int(*aui_entry)(const AStringVector&)); \
-    static int fake_main(int argc, char** argv) {                               \
-        return aui_main(argc, argv, aui_entry);\
-    } \
 [[maybe_unused]] static int _fake_aui_entry(const AStringVector& args)
 #else
 #define AUI_ENTRY \

--- a/examples/7guis/flight_booker/CMakeLists.txt
+++ b/examples/7guis/flight_booker/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 auib_import(ctre https://github.com/hanickadot/compile-time-regular-expressions
-            VERSION v3.9.0)
+            VERSION v3.10.0)
 
 aui_executable(aui.example.flight_booker)
 aui_link(aui.example.flight_booker PRIVATE aui::views ctre::ctre)

--- a/examples/7guis/flight_booker/CMakeLists.txt
+++ b/examples/7guis/flight_booker/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 auib_import(ctre https://github.com/hanickadot/compile-time-regular-expressions
-            VERSION v3.10.0)
+            VERSION 6225211806c48230e5d17a1e555ef69e7325051c)
 
 aui_executable(aui.example.flight_booker)
 aui_link(aui.example.flight_booker PRIVATE aui::views ctre::ctre)

--- a/examples/7guis/flight_booker/CMakeLists.txt
+++ b/examples/7guis/flight_booker/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 3.10)
 
 auib_import(ctre https://github.com/hanickadot/compile-time-regular-expressions
-            VERSION 6225211806c48230e5d17a1e555ef69e7325051c)
+            VERSION 6225211806c48230e5d17a1e555ef69e7325051c
+            CMAKE_ARGS -DCTRE_BUILD_TESTS=OFF)
 
 aui_executable(aui.example.flight_booker)
 aui_link(aui.example.flight_booker PRIVATE aui::views ctre::ctre)


### PR DESCRIPTION
RelWithDebugInfo requires MultiThreaded, not MultiThreadedDebug