### PR TITLE
BackgroundImage: fix render scale

### DIFF
--- a/aui.views/src/AUI/ASS/Property/BackgroundImage.cpp
+++ b/aui.views/src/AUI/ASS/Property/BackgroundImage.cpp
@@ -146,7 +146,7 @@ void ass::prop::Property<ass::BackgroundImage>::draw(
             break;
         }
         case Sizing::SPLIT_2X2: {
-            auto ratio = ctx.render.getRenderScale() / info.dpiMargin.orDefault(1.f);
+            auto ratio = AWindow::current()->getDpiRatio() / info.dpiMargin.orDefault(1.f);
             auto textureSize = glm::vec2(drawable->getSizeHint()) * ratio;
             auto textureWidth = textureSize.x;
             auto textureHeight = textureSize.y;


### PR DESCRIPTION
Fixed by changing from getRenderScale to AWindow::current()->getDpiRatio()

@Nelonn i suggest removing getRenderScale/setRenderScale from renderer but it's up to you.