### PR TITLE
AFuture: hotfix onError race condition

### DIFF
--- a/aui.core/src/AUI/Thread/AFuture.h
+++ b/aui.core/src/AUI/Thread/AFuture.h
@@ -172,6 +172,11 @@ namespace aui::impl::future {
                 return bool(value);
             }
 
+            [[nodiscard]]
+            bool hasException() const noexcept {
+                return bool(exception);
+            }
+
             bool setThread(_<AAbstractThread> thr) noexcept {
                 std::unique_lock lock(mutex);
                 if (cancelled) return true;
@@ -406,6 +411,14 @@ namespace aui::impl::future {
         }
 
         /**
+         * @return true if the exception was received.
+         */
+        [[nodiscard]]
+        bool hasException() const noexcept {
+            return (*mInner)->hasException();
+        }
+
+        /**
          * @return true if asynchronous operation was successfuly completed and supplied a value, which can be obtained
          * without waiting.
          */
@@ -434,7 +447,15 @@ namespace aui::impl::future {
 
         template<aui::invocable<const AException&> Callback>
         void onError(Callback&& callback) const {
+            if (hasException()) { // cheap lookahead
+                std::invoke(callback, *(*mInner)->exception);
+                return;
+            }
             std::unique_lock lock((*mInner)->mutex);
+            if (hasException()) { // not so cheap, but cheapier than adding the callback to inner
+                std::invoke(callback, *(*mInner)->exception);
+                return;
+            }
             (*mInner)->addOnErrorCallback(std::forward<Callback>(callback));
         }
 
@@ -615,8 +636,15 @@ namespace aui::impl::future {
  * AFuture provides a set of functions for both "value emitting" side: supplyValue(), supplyException(), and "value
  * receiving" side: operator->(), operator*(), get().
  *
- * When AFuture's operation is completed it calls either onSuccess() or onError(). These callbacks are excepted to be
- * called in any case. Use onFinally() to handle both.
+ * When AFuture's operation is completed, it calls either `onSuccess()` (on success) or `onError()` (on failure).
+ * Use `onFinally()` to handle both cases with a single callback.
+ *
+ * These callbacks are guaranteed to be called in exactly one of two moments:
+ * - **during resolution** — called by `supplyValue()`/`supplyException()` right after the result is stored;
+ * - **at subscription time** — if the future is already resolved when `onSuccess()`/`onError()` is called,
+ *   the callback is invoked immediately.
+ *
+ * This design eliminates the race condition between checking the resolution state and registering a callback.
  *
  * AFuture is a shared_ptr-based wrapper so it can be easily copied, pointing to the same task.
  *


### PR DESCRIPTION
Despite being documented, unlike onSuccess, onError didn't call its callback when AException was already reported