### PR TITLE
Fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,11 +266,11 @@ Please refer to [CONTRIBUTING.md](https://github.com/aui-framework/aui/blob/mast
 ## Star History
 
 <div align = center>
- <a href="https://www.star-history.com/#aui-framework/aui&Date">
+ <a href="https://star-history.dera.page/#aui-framework/aui&Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=aui-framework/aui&type=Date&theme=dark" />
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=aui-framework/aui&type=Date" />
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=aui-framework/aui&type=Date" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=aui-framework/aui&type=Date&theme=dark" />
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=aui-framework/aui&type=Date" />
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=aui-framework/aui&type=Date" />
   </picture>
  </a>
 </div>


### PR DESCRIPTION
The star history chart in our README is currently broken due to GitHub stargazer API restrictions. This change points it to a working alternative data source that requires no token, so visitors can see the project's growth again.