### PR TITLE
setContents(Label {"Test"}): better diagnostics

### DIFF
--- a/aui.core/src/AUI/Common/SharedPtrTypes.h
+++ b/aui.core/src/AUI/Common/SharedPtrTypes.h
@@ -249,8 +249,10 @@ public:
 
     template <typename F>
     Arc(F&& f)
-        requires requires { aui::implicit_shared_ptr_ctor<F>{}; }
-      : std::shared_ptr<T>(aui::implicit_shared_ptr_ctor<F>{}(std::forward<F>(f))) {}
+        requires requires(F&& f) {
+            { aui::implicit_shared_ptr_ctor<std::decay_t<F>>{}(std::forward<F>(f)) } -> aui::convertible_to<std::shared_ptr<T>>;
+        }
+      : std::shared_ptr<T>(aui::implicit_shared_ptr_ctor<std::decay_t<F>>{}(std::forward<F>(f))) {}
 
     Arc& operator=(const Arc& rhs) noexcept {
         std::shared_ptr<T>::operator=(rhs);

--- a/aui.core/src/AUI/Traits/concepts.h
+++ b/aui.core/src/AUI/Traits/concepts.h
@@ -155,8 +155,61 @@ namespace aui {
     static_assert(!is_tuple<int>);
     static_assert(!is_tuple<double>);
 
+    /**
+     * @brief A variable template that always evaluates to false, dependent on template parameters.
+     * @ingroup useful_templates
+     * @details
+     * In C++ prior to C++23 (CWG2518), a non-dependent `static_assert(false, "...")` inside a template
+     * definition is ill-formed and causes a compilation error even if the template is never instantiated.
+     *
+     * Passing template arguments to `aui::always_false<T...>` makes the condition dependent on template
+     * parameters, deferring the assertion evaluation until template instantiation.
+     *
+     * ### Possible Use Cases
+     *
+     * #### 1. Custom compile-time diagnostic in fallback overloads
+     * Providing a clear, user-friendly compile error instead of a generic "no matching function" error:
+     * ```cpp
+     * template <typename Container>
+     * requires (!aui::convertible_to<Container, _<AViewContainer>>)
+     * void setContents(Container&&) {
+     *     static_assert(
+     *         aui::always_false<Container>,
+     *         "Passed an AView instead of AViewContainer; wrap AView with some kind of container");
+     * }
+     * ```
+     *
+     * #### 2. Exhaustiveness check in `if constexpr` ladders
+     * Ensuring that all expected types are handled at compile time:
+     * ```cpp
+     * template <typename T>
+     * void process(const T& value) {
+     *     if constexpr (std::is_integral_v<T>) {
+     *         processInt(value);
+     *     } else if constexpr (std::is_floating_point_v<T>) {
+     *         processFloat(value);
+     *     } else {
+     *         static_assert(aui::always_false<T>, "Unsupported type passed to process()");
+     *     }
+     * }
+     * ```
+     *
+     * #### 3. Primary template poisoning
+     * Forcing explicit specialization of a template class or struct:
+     * ```cpp
+     * template <typename T>
+     * struct Serializer {
+     *     static_assert(aui::always_false<T>, "Serializer must be specialized for type T");
+     * };
+     * ```
+     *
+     * @tparam Types Template arguments used to make the boolean condition dependent on template parameters.
+     */
     template<typename...>
     inline constexpr bool always_false = false;
+    static_assert(!always_false<>);
+    static_assert(!always_false<int>);
+    static_assert(!always_false<int, double>);
 }
 
 // AObject-related concepts

--- a/aui.core/src/AUI/Traits/concepts.h
+++ b/aui.core/src/AUI/Traits/concepts.h
@@ -154,6 +154,9 @@ namespace aui {
     static_assert(is_tuple<std::tuple<double>>);
     static_assert(!is_tuple<int>);
     static_assert(!is_tuple<double>);
+
+    template<typename...>
+    inline constexpr bool always_false = false;
 }
 
 // AObject-related concepts

--- a/aui.uitests/tests/UILayoutTest.cpp
+++ b/aui.uitests/tests/UILayoutTest.cpp
@@ -434,3 +434,12 @@ TEST_F(UILayoutTest, Margin7) {
 
     AUI_REPEAT(10) { uitest::frame(); }
 }
+
+static_assert(aui::convertible_to<declarative::Centered, _<AViewContainer>>);
+static_assert(aui::convertible_to<declarative::Vertical, _<AViewContainer>>);
+static_assert(aui::convertible_to<declarative::Horizontal, _<AViewContainer>>);
+static_assert(aui::convertible_to<declarative::Stacked, _<AViewContainer>>);
+static_assert(aui::convertible_to<declarative::Button, _<AViewContainer>>);
+static_assert(!aui::convertible_to<declarative::Label, _<AViewContainer>>);
+static_assert(!aui::convertible_to<_<AView>, _<AViewContainer>>);
+static_assert(!aui::convertible_to<_<ALabel>, _<AViewContainer>>);

--- a/aui.views/src/AUI/Util/Declarative/Containers.h
+++ b/aui.views/src/AUI/Util/Declarative/Containers.h
@@ -28,7 +28,11 @@ public:
     view_helper() {}
 
     operator View() const { return asViewFactory()->operator()(); }
-    operator ViewContainer() const { return asViewFactory()->operator()(); }
+    operator ViewContainer() const
+        requires requires(ViewFactory f) { { f() } -> aui::convertible_to<ViewContainer>; }
+    {
+        return asViewFactory()->operator()();
+    }
     auto operator<<(const AString& assEntry) const { return asViewFactory()->operator()() << assEntry; }
     template <typename T>
     auto operator^(const T& t) const {

--- a/aui.views/src/AUI/View/AView.h
+++ b/aui.views/src/AUI/View/AView.h
@@ -1282,8 +1282,8 @@ API_AUI_VIEWS std::ostream& operator<<(std::ostream& os, const AView& view);
 template <typename Factory>
 requires aui::not_overloaded_lambda<Factory> && aui::factory<Factory, _<AView>>
 struct aui::implicit_shared_ptr_ctor<Factory> {
-    auto operator()(Factory&& factory) {
-        auto view = std::invoke(std::forward<Factory>(factory));
+    auto operator()(auto&& factory) {
+        auto view = std::invoke(std::forward<decltype(factory)>(factory));
         static constinit auto name = AClass<std::decay_t<Factory>>::name();
         view->addAssName(name);
         return view;

--- a/aui.views/src/AUI/View/AViewContainerBase.h
+++ b/aui.views/src/AUI/View/AViewContainerBase.h
@@ -401,6 +401,14 @@ protected:
      */
     void setContents(const _<AViewContainer>& container);
 
+    template <typename Container>
+    requires (!aui::convertible_to<Container, _<AViewContainer>>)
+    void setContents(Container&&) {
+        static_assert(
+            aui::always_false<Container>,
+            "====================> AViewContainer::setContents: Passed an AView instead of AViewContainer; wrap AView with some kind of container, i.e., view -> Centered { view }");
+    }
+
     /**
      * @brief Set new layout manager for this AViewContainerBase. DESTROYS OLD LAYOUT MANAGER WITH ITS VIEWS!!!
      */


### PR DESCRIPTION
Resolves: https://github.com/aui-framework/aui/issues/620

 An example with:

 ```cpp
#include <AUI/Platform/Entry.h>
#include <AUI/Platform/AWindow.h>
#include <AUI/Util/UIBuildingHelpers.h>
#include <AUI/View/ALabel.h>

using namespace declarative;

AUI_ENTRY {
  auto w = _new<AWindow>("test");
  w->setContents(Label { "test" });
  return 0;
}
 ```

 produces the following compiler diagnostic:

 ```text
/home/lin/works/aui/aui.views/src/AUI/View/AViewContainerBase.h:408:13: error: static assertion failed due to requirement 'aui::always_false<declarative::Label>':
====================> AViewContainer::setContents: Passed an AView instead of AViewContainer; wrap AView with some kind of container, i.e., view -> Centered { view }
  408 |             aui::always_false<Container>,
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
note: in instantiation of function template specialization 'AViewContainerBase::setContents<declarative::Label>' requested here
   22 |   w->setContents(Label { "test" });
      |      ^
 ```