### PR TITLE
Cross-platform custom captions, native menus, and macOS windowing fixes

### DIFF
--- a/aui.views/src/AUI/ASS/AStylesheet.cpp
+++ b/aui.views/src/AUI/ASS/AStylesheet.cpp
@@ -593,6 +593,11 @@ AStylesheet::AStylesheet() {
             c(".menu-item-shortcut"),
             TextColor { 0x404040_rgb },
         },
+        {
+            c(".menu-item-icon"),
+            FixedSize { 16_dp },
+            Margin { 0, 6_dp, 0, 0 },
+        },
 
         {
             c::disabled(".menu-item"),

--- a/aui.views/src/AUI/Action/AMenu.cpp
+++ b/aui.views/src/AUI/Action/AMenu.cpp
@@ -18,21 +18,52 @@
 #include <AUI/Action/MenuProvider/AEmbedMenuProvider.h>
 #include "AMenu.h"
 
+#if AUI_PLATFORM_MACOS
+#include "AUI/Platform/macos/MacOSMenuProvider.h"
+#elif AUI_PLATFORM_WIN
+#include "AUI/Platform/win32/Win32MenuProvider.h"
+#endif
+
+namespace {
+bool gUseSystemMenus = false;
+_<IMenuProvider> gOverrideProvider;
+_<IMenuProvider> gCachedProvider;
+
+void resetCache() { gCachedProvider.reset(); }
+}
+
 void AMenu::show(const AMenuModel& model) {
     provider()->createMenu(model);
 }
 
 _<IMenuProvider>& AMenu::provider() {
-    static _<IMenuProvider> provider = nullptr;
-    if (provider == nullptr) {
-        if (dynamic_cast<AWindow*>(AWindow::current())) {
-            provider = _new<AWindowMenuProvider>();
-        } else {
-            provider = _new<AEmbedMenuProvider>();
-        }
+    if (gCachedProvider) {
+        return gCachedProvider;
     }
 
-    return provider;
+    if (gOverrideProvider) {
+        gCachedProvider = gOverrideProvider;
+        return gCachedProvider;
+    }
+
+    if (!dynamic_cast<AWindow*>(AWindow::current())) {
+        gCachedProvider = _new<AEmbedMenuProvider>();
+        return gCachedProvider;
+    }
+
+    if (gUseSystemMenus) {
+#if AUI_PLATFORM_MACOS
+        gCachedProvider = _new<MacOSMenuProvider>();
+        return gCachedProvider;
+#elif AUI_PLATFORM_WIN
+        gCachedProvider = _new<Win32MenuProvider>();
+        return gCachedProvider;
+#endif
+        // No system-menu implementation on this platform — fall through to AUI-drawn.
+    }
+
+    gCachedProvider = _new<AWindowMenuProvider>();
+    return gCachedProvider;
 }
 
 void AMenu::close() {
@@ -41,4 +72,17 @@ void AMenu::close() {
 
 bool AMenu::isOpen() {
     return provider()->isOpen();
+}
+
+void AMenu::setUseSystemMenus(bool enabled) {
+    if (gUseSystemMenus == enabled) {
+        return;
+    }
+    gUseSystemMenus = enabled;
+    resetCache();
+}
+
+void AMenu::setGlobalProvider(_<IMenuProvider> provider) {
+    gOverrideProvider = std::move(provider);
+    resetCache();
 }

--- a/aui.views/src/AUI/Action/AMenu.cpp
+++ b/aui.views/src/AUI/Action/AMenu.cpp
@@ -78,11 +78,17 @@ void AMenu::setUseSystemMenus(bool enabled) {
     if (gUseSystemMenus == enabled) {
         return;
     }
+    if (gCachedProvider && gCachedProvider->isOpen()) {
+        gCachedProvider->closeMenu();
+    }
     gUseSystemMenus = enabled;
     resetCache();
 }
 
 void AMenu::setGlobalProvider(_<IMenuProvider> provider) {
+    if (gCachedProvider && gCachedProvider->isOpen()) {
+        gCachedProvider->closeMenu();
+    }
     gOverrideProvider = std::move(provider);
     resetCache();
 }

--- a/aui.views/src/AUI/Action/AMenu.h
+++ b/aui.views/src/AUI/Action/AMenu.h
@@ -22,6 +22,7 @@
 #include "AShortcut.h"
 
 class IMenuProvider;
+class IDrawable;
 struct AMenuItem;
 
 using AMenuModel = AVector<AMenuItem>;
@@ -33,6 +34,25 @@ public:
     static void show(const AMenuModel& model);
     static void close();
     static bool isOpen();
+
+    /**
+     * @brief Switches context menu rendering to the platform-native provider.
+     * @details
+     * By default AUI draws its own menus for cross-platform theme consistency. Calling
+     * `setUseSystemMenus(true)` opts in to native `NSMenu` on macOS and `HMENU`
+     * (`TrackPopupMenuEx`) on Windows — giving native appearance, VoiceOver/Narrator
+     * integration, and system-level animations. On Linux/X11 there is no system-wide
+     * native context menu API; this flag is a no-op and the AUI-drawn provider is kept.
+     */
+    static void setUseSystemMenus(bool enabled = true);
+
+    /**
+     * @brief Install a custom provider (overrides both the default and the system setting).
+     * @details
+     * Useful for testing, embedded renderers, or apps that want a fully custom menu look
+     * and feel. Pass `nullptr` to reset to the default factory behaviour.
+     */
+    static void setGlobalProvider(_<IMenuProvider> provider);
 
     enum Type {
         SINGLE,
@@ -49,5 +69,14 @@ struct AMenuItem {
     std::function<void()> onAction;
     AVector<AMenuItem> subItems;
     bool enabled = true;
+
+    /**
+     * @brief Optional icon shown to the left of the menu item label.
+     * @details
+     * Honoured by native providers (NSMenu / HMENU) when `AMenu::setUseSystemMenus(true)`
+     * and by the AUI-drawn provider. On macOS the drawable is rasterised to 16pt, on
+     * Windows to 16×16 physical pixels.
+     */
+    _<IDrawable> icon;
 };
 

--- a/aui.views/src/AUI/Action/AMenu.h
+++ b/aui.views/src/AUI/Action/AMenu.h
@@ -43,6 +43,7 @@ public:
      * (`TrackPopupMenuEx`) on Windows — giving native appearance, VoiceOver/Narrator
      * integration, and system-level animations. On Linux/X11 there is no system-wide
      * native context menu API; this flag is a no-op and the AUI-drawn provider is kept.
+     * Call from the UI thread; the cached provider is swapped without synchronization.
      */
     static void setUseSystemMenus(bool enabled = true);
 
@@ -51,6 +52,7 @@ public:
      * @details
      * Useful for testing, embedded renderers, or apps that want a fully custom menu look
      * and feel. Pass `nullptr` to reset to the default factory behaviour.
+     * Call from the UI thread; the cached provider is swapped without synchronization.
      */
     static void setGlobalProvider(_<IMenuProvider> provider);
 

--- a/aui.views/src/AUI/Action/AMenu.h
+++ b/aui.views/src/AUI/Action/AMenu.h
@@ -69,14 +69,5 @@ struct AMenuItem {
     std::function<void()> onAction;
     AVector<AMenuItem> subItems;
     bool enabled = true;
-
-    /**
-     * @brief Optional icon shown to the left of the menu item label.
-     * @details
-     * Honoured by native providers (NSMenu / HMENU) when `AMenu::setUseSystemMenus(true)`
-     * and by the AUI-drawn provider. On macOS the drawable is rasterised to 16pt, on
-     * Windows to 16×16 physical pixels.
-     */
     _<IDrawable> icon;
 };
-

--- a/aui.views/src/AUI/Action/MenuProvider/AWindowMenuProvider.cpp
+++ b/aui.views/src/AUI/Action/MenuProvider/AWindowMenuProvider.cpp
@@ -17,9 +17,11 @@
 
 #include <AUI/Common/ATimer.h>
 #include <AUI/Common/AVector.h>
+#include <AUI/Image/IDrawable.h>
 #include <AUI/Layout/AVerticalLayout.h>
 #include <AUI/Platform/ADesktop.h>
 #include <AUI/Util/UIBuildingHelpers.h>
+#include <AUI/View/ADrawableView.h>
 #include <AUI/View/ALabel.h>
 
 using namespace declarative;
@@ -60,15 +62,18 @@ class AMenuContainer : public AViewContainerBase {
         setLayout(std::make_unique<AVerticalLayout>());
         for (auto& i : vector) {
             _<AView> view;
+            auto icon = (i.icon ? _new<ADrawableView>(i.icon) : _new<ADrawableView>()) << ".menu-item-icon";
 
             switch (i.type) {
                 case AMenu::SINGLE: {
                     if (i.shortcut.empty()) {
                         addView(view = Horizontal {
+                            icon,
                             _new<ALabel>(i.name) << ".menu-item-name",
                         } << ".menu-item");
                     } else {
                         addView(view = Horizontal {
+                            icon,
                             _new<ALabel>(i.name) << ".menu-item-name",
                             _new<ASpacerExpanding>(),
                             _new<ALabel>(i.shortcut) << ".menu-item-shortcut"
@@ -96,6 +101,7 @@ class AMenuContainer : public AViewContainerBase {
 
                 case AMenu::SUBLIST: {
                     addView(view = Horizontal {
+                        icon,
                         _new<ALabel>(i.name) << ".menu-item-name",
                         _new<ASpacerExpanding>(),
                         _new<ALabel>(">")

--- a/aui.views/src/AUI/Action/MenuProvider/IMenuProvider.h
+++ b/aui.views/src/AUI/Action/MenuProvider/IMenuProvider.h
@@ -16,6 +16,7 @@
 
 class IMenuProvider {
 public:
+    virtual ~IMenuProvider() = default;
     virtual void createMenu(const AVector<AMenuItem>& vector) = 0;
     virtual void closeMenu() = 0;
     virtual bool isOpen() = 0;

--- a/aui.views/src/AUI/Enum/WindowStyle.h
+++ b/aui.views/src/AUI/Enum/WindowStyle.h
@@ -46,6 +46,21 @@ AUI_ENUM_FLAG(WindowStyle)
     SYS = 0x8,
 
     /**
+    * @brief Hides the OS-drawn title bar while keeping the system minimize/maximize/close controls.
+    *
+    * Per-platform behavior:
+    *  - macOS: title bar becomes transparent and the title text is hidden; the traffic-light
+    *    buttons remain visible, positioned by AppKit. The window keeps its system-managed
+    *    rounded corners and shadow.
+    *  - Windows: the caption area is collapsed via WM_NCCALCSIZE, and DwmExtendFrameIntoClientArea
+    *    is used so DWM continues to paint the min/max/close glyphs over the client area. The
+    *    application is responsible for reserving space for the buttons and providing a drag
+    *    region via WM_NCHITTEST (HTCAPTION).
+    *  - Linux/X11: not yet implemented — behaves like NO_DECORATORS.
+    */
+    NO_TITLEBAR = 0x10,
+
+    /**
     * @brief Enables transparency for this window, so it can be displayed as custom rounded shadowed rectangle.
     * TODO implement WS_TRANSPARENT. WinAPI: http://rsdn.org/article/opengl/layeredopengl.xml, X11: https://github.com/datenwolf/codesamples/blob/master/samples/OpenGL/x11argb_opengl/x11argb_opengl.c
     */

--- a/aui.views/src/AUI/Enum/WindowStyle.h
+++ b/aui.views/src/AUI/Enum/WindowStyle.h
@@ -47,16 +47,6 @@ AUI_ENUM_FLAG(WindowStyle)
 
     /**
     * @brief Hides the OS-drawn title bar while keeping the system minimize/maximize/close controls.
-    *
-    * Per-platform behavior:
-    *  - macOS: title bar becomes transparent and the title text is hidden; the traffic-light
-    *    buttons remain visible, positioned by AppKit. The window keeps its system-managed
-    *    rounded corners and shadow.
-    *  - Windows: the caption area is collapsed via WM_NCCALCSIZE, and DwmExtendFrameIntoClientArea
-    *    is used so DWM continues to paint the min/max/close glyphs over the client area. The
-    *    application is responsible for reserving space for the buttons and providing a drag
-    *    region via WM_NCHITTEST (HTCAPTION).
-    *  - Linux/X11: not yet implemented — behaves like NO_DECORATORS.
     */
     NO_TITLEBAR = 0x10,
 

--- a/aui.views/src/AUI/Platform/ACustomCaptionWindow.cpp
+++ b/aui.views/src/AUI/Platform/ACustomCaptionWindow.cpp
@@ -12,7 +12,7 @@
 #include "ACustomCaptionWindow.h"
 #include <AUI/Util/UIBuildingHelpers.h>
 
-ACustomCaptionWindow::ACustomCaptionWindow(const AString& name, int width, int height, bool stacked, AWindow* parent, WindowStyle ws)
+ACustomCaptionWindow::ACustomCaptionWindow(const AString& name, AMetric width, AMetric height, bool stacked, AWindow* parent, WindowStyle ws)
   : ACustomWindow(name, width, height, parent), CustomCaptionWindowImplCurrent() {
     setWindowStyle(windowStyle() | ws);
     initCustomCaption(name, stacked, this);

--- a/aui.views/src/AUI/Platform/ACustomCaptionWindow.cpp
+++ b/aui.views/src/AUI/Platform/ACustomCaptionWindow.cpp
@@ -12,8 +12,8 @@
 #include "ACustomCaptionWindow.h"
 #include <AUI/Util/UIBuildingHelpers.h>
 
-ACustomCaptionWindow::ACustomCaptionWindow(const AString& name, int width, int height, bool stacked)
-  : ACustomWindow(name, width, height), CustomCaptionWindowImplCurrent() {
+ACustomCaptionWindow::ACustomCaptionWindow(const AString& name, int width, int height, bool stacked, AWindow* parent)
+  : ACustomWindow(name, width, height, parent), CustomCaptionWindowImplCurrent() {
     initCustomCaption(name, stacked, this);
 
     connect(minimized, this, [&]() { updateMiddleButtonIcon(); });

--- a/aui.views/src/AUI/Platform/ACustomCaptionWindow.cpp
+++ b/aui.views/src/AUI/Platform/ACustomCaptionWindow.cpp
@@ -14,9 +14,7 @@
 
 ACustomCaptionWindow::ACustomCaptionWindow(const AString& name, int width, int height, bool stacked, AWindow* parent, WindowStyle ws)
   : ACustomWindow(name, width, height, parent), CustomCaptionWindowImplCurrent() {
-    if (ws != WindowStyle::DEFAULT) {
-        setWindowStyle(windowStyle() | ws);
-    }
+    setWindowStyle(windowStyle() | ws);
     initCustomCaption(name, stacked, this);
 
     connect(minimized, this, [&]() { updateMiddleButtonIcon(); });

--- a/aui.views/src/AUI/Platform/ACustomCaptionWindow.cpp
+++ b/aui.views/src/AUI/Platform/ACustomCaptionWindow.cpp
@@ -12,8 +12,11 @@
 #include "ACustomCaptionWindow.h"
 #include <AUI/Util/UIBuildingHelpers.h>
 
-ACustomCaptionWindow::ACustomCaptionWindow(const AString& name, int width, int height, bool stacked, AWindow* parent)
+ACustomCaptionWindow::ACustomCaptionWindow(const AString& name, int width, int height, bool stacked, AWindow* parent, WindowStyle ws)
   : ACustomWindow(name, width, height, parent), CustomCaptionWindowImplCurrent() {
+    if (ws != WindowStyle::DEFAULT) {
+        setWindowStyle(windowStyle() | ws);
+    }
     initCustomCaption(name, stacked, this);
 
     connect(minimized, this, [&]() { updateMiddleButtonIcon(); });

--- a/aui.views/src/AUI/Platform/ACustomCaptionWindow.cpp
+++ b/aui.views/src/AUI/Platform/ACustomCaptionWindow.cpp
@@ -13,21 +13,30 @@
 #include <AUI/Util/UIBuildingHelpers.h>
 
 ACustomCaptionWindow::ACustomCaptionWindow(const AString& name, int width, int height, bool stacked)
-  : ACustomWindow(name, width, height), CustomCaptionWindowImplWin32() {
+  : ACustomWindow(name, width, height), CustomCaptionWindowImplCurrent() {
     initCustomCaption(name, stacked, this);
-    connect(mMiddleButton->clickedButton, this, [&]() {
-        if (isMaximized()) {
-            restore();
-        } else {
-            maximize();
-        }
-    });
 
     connect(minimized, this, [&]() { updateMiddleButtonIcon(); });
     connect(restored, this, [&]() { updateMiddleButtonIcon(); });
     connect(maximized, this, [&]() { updateMiddleButtonIcon(); });
-    connect(mCloseButton->clickedButton, this, &AWindow::quit);
-    connect(mMinimizeButton->clickedButton, this, &AWindow::minimize);
+
+    if (mMiddleButton) {
+        connect(mMiddleButton->clickedButton, this, [&]() {
+            if (isMaximized()) {
+                restore();
+            } else {
+                maximize();
+            }
+        });
+    }
+
+    if (mCloseButton) {
+        connect(mCloseButton->clickedButton, this, &AWindow::quit);
+    }
+
+    if (mMinimizeButton) {
+        connect(mMinimizeButton->clickedButton, this, &AWindow::minimize);
+    }
 }
 
 bool ACustomCaptionWindow::isCustomCaptionMaximized() { return isMaximized(); }

--- a/aui.views/src/AUI/Platform/ACustomCaptionWindow.h
+++ b/aui.views/src/AUI/Platform/ACustomCaptionWindow.h
@@ -64,7 +64,7 @@ class API_AUI_VIEWS ACustomCaptionWindow : public ACustomWindow, private CustomC
     friend class ACustomWindow;
 
 public:
-    ACustomCaptionWindow(const AString& name, int width, int height, bool stacked = false);
+    ACustomCaptionWindow(const AString& name, int width, int height, bool stacked = false, AWindow* parent = nullptr);
 
     ACustomCaptionWindow() : ACustomCaptionWindow("Custom Caption Window", 240, 124) {}
 

--- a/aui.views/src/AUI/Platform/ACustomCaptionWindow.h
+++ b/aui.views/src/AUI/Platform/ACustomCaptionWindow.h
@@ -64,7 +64,12 @@ class API_AUI_VIEWS ACustomCaptionWindow : public ACustomWindow, private CustomC
     friend class ACustomWindow;
 
 public:
-    ACustomCaptionWindow(const AString& name, int width, int height, bool stacked = false, AWindow* parent = nullptr);
+    ACustomCaptionWindow(const AString& name,
+                         int width,
+                         int height,
+                         bool stacked = false,
+                         AWindow* parent = nullptr,
+                         WindowStyle ws = WindowStyle::DEFAULT);
 
     ACustomCaptionWindow() : ACustomCaptionWindow("Custom Caption Window", 240, 124) {}
 

--- a/aui.views/src/AUI/Platform/ACustomCaptionWindow.h
+++ b/aui.views/src/AUI/Platform/ACustomCaptionWindow.h
@@ -14,9 +14,17 @@
 #include <AUI/View/AButton.h>
 #include <AUI/View/ASpacerExpanding.h>
 #include <AUI/Util/UIBuildingHelpers.h>
-#include "CustomCaptionWindowImplWin32.h"
 
+#if AUI_PLATFORM_WIN
+#include "win32/CustomCaptionWindowImplWin32.h"
 using CustomCaptionWindowImplCurrent = CustomCaptionWindowImplWin32;
+#elif AUI_PLATFORM_MACOS
+#include "macos/CustomCaptionWindowImplMacos.h"
+using CustomCaptionWindowImplCurrent = CustomCaptionWindowImplMacos;
+#else
+#include "linux/CustomCaptionWindowImplLinux.h"
+using CustomCaptionWindowImplCurrent = CustomCaptionWindowImplLinux;
+#endif
 
 
 /**
@@ -42,11 +50,19 @@ using CustomCaptionWindowImplCurrent = CustomCaptionWindowImplWin32;
  * - ".middle" for maximize button
  *
  *
- * @specificto{windows}
- * Since Windows does not provide APIs to the customize caption, AUI implements and renders caption by itself, including
- * window icon, title and buttons.
+ * Per-platform behavior:
+ *  - Windows: caption, title label, and the three system buttons are rendered by AUI. The
+ *    buttons participate in `WM_NCHITTEST` so Win11 snap-layout flyouts work and the OS
+ *    dispatches SC_MINIMIZE/SC_MAXIMIZE/SC_CLOSE natively. NC hover is reflected back to
+ *    the AUI buttons via the `.nc-hover` ASS class.
+ *  - macOS: the caption container leaves room for AppKit's native traffic lights on the
+ *    left; the `.minimize`/`.middle`/`.close` buttons are not created (the OS owns those).
+ *  - Linux/X11: all caption chrome is drawn by AUI (full CSD); dragging the caption
+ *    delegates to the window manager via the `_NET_WM_MOVERESIZE` EWMH client message.
  */
 class API_AUI_VIEWS ACustomCaptionWindow : public ACustomWindow, private CustomCaptionWindowImplCurrent {
+    friend class ACustomWindow;
+
 public:
     ACustomCaptionWindow(const AString& name, int width, int height, bool stacked = false);
 

--- a/aui.views/src/AUI/Platform/ACustomCaptionWindow.h
+++ b/aui.views/src/AUI/Platform/ACustomCaptionWindow.h
@@ -65,8 +65,8 @@ class API_AUI_VIEWS ACustomCaptionWindow : public ACustomWindow, private CustomC
 
 public:
     ACustomCaptionWindow(const AString& name,
-                         int width,
-                         int height,
+                         AMetric width,
+                         AMetric height,
                          bool stacked = false,
                          AWindow* parent = nullptr,
                          WindowStyle ws = WindowStyle::DEFAULT);

--- a/aui.views/src/AUI/Platform/ACustomWindow.h
+++ b/aui.views/src/AUI/Platform/ACustomWindow.h
@@ -22,7 +22,7 @@ class API_AUI_VIEWS ACustomWindow: public AWindow
 {
     friend class AWindowManager;
 public:
-    ACustomWindow(const AString& name, int width, int height, AWindow* parent = nullptr);
+    ACustomWindow(const AString& name, AMetric width, AMetric height, AWindow* parent = nullptr);
     ACustomWindow() = default;
     ~ACustomWindow() override = default;
 

--- a/aui.views/src/AUI/Platform/ASurface.cpp
+++ b/aui.views/src/AUI/Platform/ASurface.cpp
@@ -40,12 +40,12 @@ ASurface::ASurface() {
 
 ASurface::~ASurface() {
     // Close any overlapping surfaces (context menus, dropdowns, tooltips) that were attached to this window.
-    AVector<AOverlappingSurface*> toClose;
+    AVector<_<AOverlappingSurface>> toClose;
     toClose.reserve(mOverlappingSurfaces.size());
     for (auto& surface : mOverlappingSurfaces) {
-        toClose << surface.get();
+        toClose << surface;
     }
-    for (auto* surface : toClose) {
+    for (auto& surface : toClose) {
         closeOverlappingSurface(surface);
     }
 

--- a/aui.views/src/AUI/Platform/ASurface.cpp
+++ b/aui.views/src/AUI/Platform/ASurface.cpp
@@ -39,6 +39,16 @@ ASurface::ASurface() {
 }
 
 ASurface::~ASurface() {
+    // Close any overlapping surfaces (context menus, dropdowns, tooltips) that were attached to this window.
+    AVector<AOverlappingSurface*> toClose;
+    toClose.reserve(mOverlappingSurfaces.size());
+    for (auto& surface : mOverlappingSurfaces) {
+        toClose << surface.get();
+    }
+    for (auto* surface : toClose) {
+        closeOverlappingSurface(surface);
+    }
+
     if (currentWindowStorage() == this) {
         currentWindowStorage() = nullptr;
     }

--- a/aui.views/src/AUI/Platform/ASurface.h
+++ b/aui.views/src/AUI/Platform/ASurface.h
@@ -270,13 +270,11 @@ public:
                                                     const glm::ivec2& size,
                                                     bool closeOnClick = true) {
         glm::ivec2 position = {0, 0};
-        auto maxPos = getSize() - size;
         for (unsigned index = 0; ; ++index) {
             auto optionalPosition = positionFactory(index);
             if (optionalPosition) {
                 position = *optionalPosition;
-
-                if (position.x >= 0 && position.y >= 0 && glm::all(glm::lessThan(position, maxPos))) {
+                if (position.x >= 0 && position.y >= 0) {
                     break;
                 }
             } else {
@@ -515,4 +513,3 @@ private:
  *
  */
 #define AUI_ASSERT_WORKER_THREAD_ONLY() { AUI_ASSERTX(AWindow::current() == nullptr || AThread::current() != AWindow::current()->getThread(), "this method should be used in worker thread only."); }
-

--- a/aui.views/src/AUI/Platform/AWindows.cpp
+++ b/aui.views/src/AUI/Platform/AWindows.cpp
@@ -261,7 +261,7 @@ _<AOverlappingSurface> AWindow::createOverlappingSurfaceImpl(const glm::ivec2& p
     class AOverlappingWindow: public AWindow {
     public:
         AOverlappingWindow(AWindow* parent):
-        AWindow("MENU", 100, 100, parent, WindowStyle::SYS) {
+        AWindow("MENU", 100_dp, 100_dp, parent, WindowStyle::SYS) {
             setCustomStyle({ ass::Padding { 0 } });
         }
     };

--- a/aui.views/src/AUI/Platform/android/ACustomWindowImpl.cpp
+++ b/aui.views/src/AUI/Platform/android/ACustomWindowImpl.cpp
@@ -20,7 +20,7 @@ void ACustomWindow::handleXConfigureNotify() {
 }
 
 
-ACustomWindow::ACustomWindow(const AString& name, int width, int height, AWindow* parent) :
+ACustomWindow::ACustomWindow(const AString& name, AMetric width, AMetric height, AWindow* parent) :
     AWindow(name, width, height, parent) {
 }
 

--- a/aui.views/src/AUI/Platform/emscripten/ACustomWindowImpl.cpp
+++ b/aui.views/src/AUI/Platform/emscripten/ACustomWindowImpl.cpp
@@ -20,7 +20,7 @@ void ACustomWindow::handleXConfigureNotify() {
 }
 
 
-ACustomWindow::ACustomWindow(const AString& name, int width, int height, AWindow* parent) :
+ACustomWindow::ACustomWindow(const AString& name, AMetric width, AMetric height, AWindow* parent) :
     AWindow(name, width, height, parent) {
 }
 

--- a/aui.views/src/AUI/Platform/ios/ACustomWindowImpl.cpp
+++ b/aui.views/src/AUI/Platform/ios/ACustomWindowImpl.cpp
@@ -14,7 +14,7 @@
 #include <cstring>
 #include <AUI/View/AButton.h>
 
-ACustomWindow::ACustomWindow(const AString& name, int width, int height, AWindow* parent) :
+ACustomWindow::ACustomWindow(const AString& name, AMetric width, AMetric height, AWindow* parent) :
     AWindow(name, width, height, parent) {
 }
 

--- a/aui.views/src/AUI/Platform/linux/ACustomWindowImpl.cpp
+++ b/aui.views/src/AUI/Platform/linux/ACustomWindowImpl.cpp
@@ -21,7 +21,7 @@
 
 ACustomWindow::ACustomWindow(const AString& name, int width, int height, AWindow* parent) :
         AWindow(name, width, height, parent) {
-    setWindowStyle(WindowStyle::NO_DECORATORS);
+    setWindowStyle(WindowStyle::NO_TITLEBAR);
 }
 
 void ACustomWindow::onPointerPressed(const APointerPressedEvent& event) {

--- a/aui.views/src/AUI/Platform/linux/ACustomWindowImpl.cpp
+++ b/aui.views/src/AUI/Platform/linux/ACustomWindowImpl.cpp
@@ -19,7 +19,7 @@
 #include <X11/Xlib.h>
 #include <X11/Xatom.h>
 
-ACustomWindow::ACustomWindow(const AString& name, int width, int height, AWindow* parent) :
+ACustomWindow::ACustomWindow(const AString& name, AMetric width, AMetric height, AWindow* parent) :
         AWindow(name, width, height, parent) {
     setWindowStyle(WindowStyle::NO_TITLEBAR);
 }

--- a/aui.views/src/AUI/Platform/linux/ACustomWindowImpl.cpp
+++ b/aui.views/src/AUI/Platform/linux/ACustomWindowImpl.cpp
@@ -12,8 +12,12 @@
 #include "AUI/Platform/ACustomWindow.h"
 #include "AUI/Platform/ADesktop.h"
 #include "AUI/Platform/CommonRenderingContext.h"
+#include "AUI/Platform/linux/x11/PlatformAbstractionX11.h"
 #include <cstring>
 #include <AUI/View/AButton.h>
+
+#include <X11/Xlib.h>
+#include <X11/Xatom.h>
 
 ACustomWindow::ACustomWindow(const AString& name, int width, int height, AWindow* parent) :
         AWindow(name, width, height, parent) {
@@ -23,23 +27,34 @@ ACustomWindow::ACustomWindow(const AString& name, int width, int height, AWindow
 void ACustomWindow::onPointerPressed(const APointerPressedEvent& event) {
     if (event.position.y < mTitleHeight && event.asButton == AInput::LBUTTON) {
         if (isCaptionAt(event.position)) {
-            /*
-            XClientMessageEvent xclient;
-            memset(&xclient, 0, sizeof(XClientMessageEvent));
-            XUngrabPointer(PlatformAbstractionX11::ourDisplay, 0);
-            XFlush(PlatformAbstractionX11::ourDisplay);
-            xclient.type = ClientMessage;
-            xclient.window = mHandle;
-            xclient.message_type = XInternAtom(PlatformAbstractionX11::ourDisplay, "_NET_WM_MOVERESIZE", False);
-            xclient.format = 32;
-            auto newPos = ADesktop::getMousePosition();
-            xclient.data.l[0] = newPos.x;
-            xclient.data.l[1] = newPos.y;
-            xclient.data.l[2] = 8;
-            xclient.data.l[3] = 0;
-            xclient.data.l[4] = 0;
-            XSendEvent(PlatformAbstractionX11::ourDisplay, XRootWindow(PlatformAbstractionX11::ourDisplay, 0), False, SubstructureRedirectMask | SubstructureNotifyMask,
-                       (XEvent*) &xclient);*/
+            // Hand the drag off to the window manager via the EWMH _NET_WM_MOVERESIZE
+            // client message. This gives us native Aero-snap-like behaviour on KWin/Mutter
+            // (edge tiling, half-screen) while we stay in charge of the rest of the window.
+            Display* display = PlatformAbstractionX11::ourDisplay;
+            if (display && mHandle) {
+                static Atom atomMoveResize = XInternAtom(display, "_NET_WM_MOVERESIZE", False);
+                const auto rootPos = ADesktop::getMousePosition();
+
+                XUngrabPointer(display, CurrentTime);
+                XFlush(display);
+
+                XClientMessageEvent xclient;
+                std::memset(&xclient, 0, sizeof(xclient));
+                xclient.type = ClientMessage;
+                xclient.window = static_cast<Window>(mHandle);
+                xclient.message_type = atomMoveResize;
+                xclient.format = 32;
+                xclient.data.l[0] = rootPos.x;
+                xclient.data.l[1] = rootPos.y;
+                xclient.data.l[2] = 8;                       // _NET_WM_MOVERESIZE_MOVE
+                xclient.data.l[3] = Button1;                 // button that triggered the drag
+                xclient.data.l[4] = 0;                       // source indication: normal app
+                XSendEvent(display,
+                           XRootWindow(display, DefaultScreen(display)),
+                           False,
+                           SubstructureRedirectMask | SubstructureNotifyMask,
+                           reinterpret_cast<XEvent*>(&xclient));
+            }
 
             mDragging = true;
             mDragPos = event.position;

--- a/aui.views/src/AUI/Platform/linux/ACustomWindowImpl.cpp
+++ b/aui.views/src/AUI/Platform/linux/ACustomWindowImpl.cpp
@@ -61,7 +61,7 @@ void ACustomWindow::onPointerPressed(const APointerPressedEvent& event) {
             emit dragBegin(event.position);
         }
     }
-    AViewContainer::onPointerPressed(event);
+    AWindow::onPointerPressed(event);
 }
 
 

--- a/aui.views/src/AUI/Platform/linux/CustomCaptionWindowImplLinux.cpp
+++ b/aui.views/src/AUI/Platform/linux/CustomCaptionWindowImplLinux.cpp
@@ -9,27 +9,22 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-//
-// Created by alex2 on 05.12.2020.
-//
-
-#include "CustomCaptionWindowImplWin32.h"
+#include "CustomCaptionWindowImplLinux.h"
 #include <AUI/Util/UIBuildingHelpers.h>
-#include <AUI/Common/Plugin.h>
 #include <AUI/ASS/Property/BackgroundImage.h>
 
-void CustomCaptionWindowImplWin32::initCustomCaption(const AString& name, bool stacked, AViewContainer* to) {
+void CustomCaptionWindowImplLinux::initCustomCaption(const AString& name, bool stacked, AViewContainer* to) {
     auto caption = _new<AViewContainer>();
     caption->setLayout(std::make_unique<AHorizontalLayout>());
     caption->addAssName(".window-title");
-    caption->setExpanding({1, 0});
+    caption->setExpanding({ 1, 0 });
 
     auto titleLabel = _new<ALabel>(name) << ".title";
     caption->addView(titleLabel);
 
     mCaptionContainer = _new<AViewContainer>();
     mCaptionContainer->setLayout(std::make_unique<AHorizontalLayout>());
-    mCaptionContainer->setExpanding({1, 0 });
+    mCaptionContainer->setExpanding({ 1, 0 });
     mCaptionContainer->addAssName(".window-title-content");
     caption->addView(mCaptionContainer);
 
@@ -41,7 +36,6 @@ void CustomCaptionWindowImplWin32::initCustomCaption(const AString& name, bool s
     mMiddleButton = _new<AButton>();
     mMiddleButton->addAssName(".middle");
     mMiddleButton->addAssName(".default");
-
     caption->addView(mMiddleButton);
 
     mCloseButton = _new<AButton>();
@@ -53,27 +47,27 @@ void CustomCaptionWindowImplWin32::initCustomCaption(const AString& name, bool s
         to->setLayout(std::make_unique<AStackedLayout>());
         to->addView(mContentContainer = _new<AViewContainer>());
         to->addView(declarative::Vertical {
-                                                    caption,
-                                                    _new<ASpacerExpanding>(),
-                                            } AUI_LET { it->setExpanding({1, 1}); });
+            caption,
+            _new<ASpacerExpanding>(),
+        } AUI_LET { it->setExpanding({ 1, 1 }); });
     } else {
         to->setLayout(std::make_unique<AVerticalLayout>());
         to->addView(caption);
         to->addView(mContentContainer = _new<AViewContainer>());
     }
-    mContentContainer->setExpanding({1, 1});
+    mContentContainer->setExpanding({ 1, 1 });
 
     updateMiddleButtonIcon();
 }
 
-void CustomCaptionWindowImplWin32::updateMiddleButtonIcon() {
+void CustomCaptionWindowImplLinux::updateMiddleButtonIcon() {
     if (isCustomCaptionMaximized()) {
         mMiddleButton->setCustomStyle({
-            ass::BackgroundImage {":uni/caption/restore.svg", {}, {}, ass::Sizing::CENTER }
+            ass::BackgroundImage { ":uni/caption/restore.svg", {}, {}, ass::Sizing::CENTER },
         });
     } else {
         mMiddleButton->setCustomStyle({
-            ass::BackgroundImage {":uni/caption/maximize.svg", {}, {}, ass::Sizing::CENTER }
+            ass::BackgroundImage { ":uni/caption/maximize.svg", {}, {}, ass::Sizing::CENTER },
         });
     }
 }

--- a/aui.views/src/AUI/Platform/linux/CustomCaptionWindowImplLinux.cpp
+++ b/aui.views/src/AUI/Platform/linux/CustomCaptionWindowImplLinux.cpp
@@ -10,6 +10,9 @@
  */
 
 #include "CustomCaptionWindowImplLinux.h"
+#include "AUI/Platform/AWindow.h"
+#include "AUI/Enum/WindowStyle.h"
+#include "AUI/Enum/Visibility.h"
 #include <AUI/Util/UIBuildingHelpers.h>
 #include <AUI/ASS/Property/BackgroundImage.h>
 
@@ -56,6 +59,14 @@ void CustomCaptionWindowImplLinux::initCustomCaption(const AString& name, bool s
         to->addView(mContentContainer = _new<AViewContainer>());
     }
     mContentContainer->setExpanding({ 1, 1 });
+
+    // Hide the minimize/maximize buttons when the window style opts out of them.
+    if (auto* window = dynamic_cast<AWindow*>(to)) {
+        if (!!(window->windowStyle() & WindowStyle::NO_MINIMIZE_MAXIMIZE)) {
+            mMinimizeButton->setVisibility(Visibility::GONE);
+            mMiddleButton->setVisibility(Visibility::GONE);
+        }
+    }
 
     updateMiddleButtonIcon();
 }

--- a/aui.views/src/AUI/Platform/linux/CustomCaptionWindowImplLinux.h
+++ b/aui.views/src/AUI/Platform/linux/CustomCaptionWindowImplLinux.h
@@ -9,22 +9,26 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 
-//
-// Created by alex2 on 05.12.2020.
-//
-
 #pragma once
 
 #include <AUI/View/AViewContainer.h>
 #include <AUI/View/AButton.h>
 
-class API_AUI_VIEWS CustomCaptionWindowImplWin32 {
+/**
+ * @brief Linux/X11 caption implementation — full client-side decorations.
+ *
+ * X11 Motif hints cannot reliably preserve individual system buttons across compositors, so
+ * we take the Electron/VS Code approach: draw all caption chrome ourselves. The three buttons
+ * (minimize, maximize/restore, close) are AUI widgets styled via ASS, and dragging the caption
+ * is wired to the `_NET_WM_MOVERESIZE` X11 client-message in ACustomWindowImpl.
+ */
+class API_AUI_VIEWS CustomCaptionWindowImplLinux {
 protected:
     _<AViewContainer> mCaptionContainer;
     _<AViewContainer> mContentContainer;
-    _<AButton> mMinimizeButton; // _
-    _<AButton> mMiddleButton; // []
-    _<AButton> mCloseButton; // X
+    _<AButton> mMinimizeButton;
+    _<AButton> mMiddleButton;
+    _<AButton> mCloseButton;
 
     void updateMiddleButtonIcon();
     void initCustomCaption(const AString& name, bool stacked, AViewContainer* to);
@@ -32,10 +36,6 @@ protected:
     virtual bool isCustomCaptionMaximized() = 0;
 
 public:
-    CustomCaptionWindowImplWin32() = default;
-
-    virtual ~CustomCaptionWindowImplWin32() = default;
-
+    CustomCaptionWindowImplLinux() = default;
+    virtual ~CustomCaptionWindowImplLinux() = default;
 };
-
-

--- a/aui.views/src/AUI/Platform/linux/x11/cursor.cpp
+++ b/aui.views/src/AUI/Platform/linux/x11/cursor.cpp
@@ -150,7 +150,12 @@ void PlatformAbstractionX11::applyNativeCursor(const ACursor& cursor, AWindow* p
 }
 
 void PlatformAbstractionX11::windowSetStyle(AWindow& window, WindowStyle ws) {
-    if (!!(ws & (WindowStyle::SYS | WindowStyle::NO_DECORATORS))) {
+    // TODO: WindowStyle::NO_TITLEBAR — X11 Motif hints don't reliably support
+    // "keep system buttons but hide the title strip" across compositors. Implementing
+    // this properly likely requires client-side decorations (drawing our own buttons),
+    // similar to ACustomWindow. For now, NO_TITLEBAR falls through the same path
+    // as NO_DECORATORS.
+    if (!!(ws & (WindowStyle::SYS | WindowStyle::NO_DECORATORS | WindowStyle::NO_TITLEBAR))) {
         // note the struct is declared elsewhere, is here just for clarity.
         // code is from [http://tonyobryan.com/index.php?article=9][1]
         typedef struct Hints {

--- a/aui.views/src/AUI/Platform/macos/ACustomWindowImpl.cpp
+++ b/aui.views/src/AUI/Platform/macos/ACustomWindowImpl.cpp
@@ -17,7 +17,7 @@
 
 ACustomWindow::ACustomWindow(const AString& name, int width, int height, AWindow* parent) :
     AWindow(name, width, height, parent) {
-    setWindowStyle(WindowStyle::NO_DECORATORS);
+    setWindowStyle(WindowStyle::NO_TITLEBAR);
 }
 
 void ACustomWindow::onPointerPressed(const APointerPressedEvent& event) {

--- a/aui.views/src/AUI/Platform/macos/ACustomWindowImpl.mm
+++ b/aui.views/src/AUI/Platform/macos/ACustomWindowImpl.mm
@@ -14,13 +14,48 @@
 #include <cstring>
 #include <AUI/View/AButton.h>
 
+#import <Cocoa/Cocoa.h>
+
 
 ACustomWindow::ACustomWindow(const AString& name, int width, int height, AWindow* parent) :
     AWindow(name, width, height, parent) {
     setWindowStyle(WindowStyle::NO_TITLEBAR);
 }
 
+namespace {
+// A click is a caption drag candidate when its deepest view sits inside a `.window-title`
+// ancestor and is not itself an interactive widget. This ignores mTitleHeight entirely,
+// which is brittle at HiDPI (literal 30px regardless of scale) and mismatches the actual
+// caption row height set by the impl.
+bool shouldDragCaption(ACustomWindow* self, const glm::ivec2& pos) {
+    auto v = self->getViewAtRecursive(pos);
+    if (!v) return false;
+    if (_cast<AButton>(v)) return false;
+    if (v->getAssNames().contains(".override-title-dragging")) return false;
+    for (AView* cur = v.get(); cur; cur = cur->getParent()) {
+        if (cur->getAssNames().contains(".window-title")) {
+            return true;
+        }
+    }
+    return false;
+}
+}
+
 void ACustomWindow::onPointerPressed(const APointerPressedEvent& event) {
+    if (mHandle && event.asButton == AInput::LBUTTON && shouldDragCaption(this, event.position)) {
+        auto* ns = static_cast<NSWindow*>(mHandle);
+        if (NSEvent* current = [NSApp currentEvent]) {
+            const bool canZoom = !(mWindowStyle & (WindowStyle::NO_RESIZE | WindowStyle::NO_MINIMIZE_MAXIMIZE));
+            if ([current clickCount] >= 2) {
+                if (canZoom) {
+                    [ns performZoom:nil];
+                }
+                return;
+            }
+            [ns performWindowDragWithEvent:current];
+            return;
+        }
+    }
     AViewContainer::onPointerPressed(event);
 }
 

--- a/aui.views/src/AUI/Platform/macos/ACustomWindowImpl.mm
+++ b/aui.views/src/AUI/Platform/macos/ACustomWindowImpl.mm
@@ -45,7 +45,7 @@ void ACustomWindow::onPointerPressed(const APointerPressedEvent& event) {
     if (mHandle && event.asButton == AInput::LBUTTON && shouldDragCaption(this, event.position)) {
         auto* ns = static_cast<NSWindow*>(mHandle);
         if (NSEvent* current = [NSApp currentEvent]) {
-            const bool canZoom = !(mWindowStyle & (WindowStyle::NO_RESIZE | WindowStyle::NO_MINIMIZE_MAXIMIZE));
+            const bool canZoom = !(mWindowStyle & WindowStyle::NO_RESIZE);
             if ([current clickCount] >= 2) {
                 if (canZoom) {
                     [ns performZoom:nil];

--- a/aui.views/src/AUI/Platform/macos/ACustomWindowImpl.mm
+++ b/aui.views/src/AUI/Platform/macos/ACustomWindowImpl.mm
@@ -56,7 +56,7 @@ void ACustomWindow::onPointerPressed(const APointerPressedEvent& event) {
             return;
         }
     }
-    AViewContainer::onPointerPressed(event);
+    AWindow::onPointerPressed(event);
 }
 
 void ACustomWindow::onPointerReleased(const APointerReleasedEvent& event) {

--- a/aui.views/src/AUI/Platform/macos/ACustomWindowImpl.mm
+++ b/aui.views/src/AUI/Platform/macos/ACustomWindowImpl.mm
@@ -17,7 +17,7 @@
 #import <Cocoa/Cocoa.h>
 
 
-ACustomWindow::ACustomWindow(const AString& name, int width, int height, AWindow* parent) :
+ACustomWindow::ACustomWindow(const AString& name, AMetric width, AMetric height, AWindow* parent) :
     AWindow(name, width, height, parent) {
     setWindowStyle(WindowStyle::NO_TITLEBAR);
 }

--- a/aui.views/src/AUI/Platform/macos/AUIView.mm
+++ b/aui.views/src/AUI/Platform/macos/AUIView.mm
@@ -84,6 +84,14 @@ bool isEventReserved(NSEvent* event) {
     return YES;
 }
 
+- (BOOL)acceptsFirstMouse:(NSEvent*)event {
+    // Deliver the first click on a background window to the view instead of just
+    // activating the window. Without this, clicking the parent window while a popup
+    // (e.g. context menu) is open only activates the parent; the click is swallowed,
+    // so AWindowBase::onPointerPressed never fires and the popup stays open.
+    return YES;
+}
+
 - (BOOL)becomeFirstResponder {
     ALOG_DEBUG(LOG_TAG) << "becomeFirstResponder";
     return YES;

--- a/aui.views/src/AUI/Platform/macos/AWindowsImpl.mm
+++ b/aui.views/src/AUI/Platform/macos/AWindowsImpl.mm
@@ -82,11 +82,23 @@ void AWindow::show() {
 void AWindow::setWindowStyle(WindowStyle ws) {
     mWindowStyle = ws;
     if (!mHandle) return;
-    const bool hideChrome = !!(ws & (WindowStyle::SYS | WindowStyle::NO_DECORATORS));
+    auto s = static_cast<NSWindow*>(mHandle);
+
+    // SYS == popup (context menu, dropdown, tooltip)
+    if (!!(ws & WindowStyle::SYS)) {
+        [s setStyleMask:NSWindowStyleMaskBorderless];
+        [s setLevel:NSPopUpMenuWindowLevel];
+        [s setHidesOnDeactivate:YES];
+        [s setOpaque:NO];
+        [s setBackgroundColor:[NSColor clearColor]];
+        [s setHasShadow:YES];
+        return;
+    }
+
+    const bool hideChrome = !!(ws & WindowStyle::NO_DECORATORS);
     const bool customTitlebar = !!(ws & WindowStyle::NO_TITLEBAR);
     const bool hideMinMax = !!(ws & WindowStyle::NO_MINIMIZE_MAXIMIZE);
     const bool noResize = !!(ws & WindowStyle::NO_RESIZE);
-    auto s = static_cast<NSWindow*>(mHandle);
     if (hideChrome || customTitlebar) {
         [s setStyleMask:([s styleMask] | NSWindowStyleMaskFullSizeContentView)];
         [s setTitlebarAppearsTransparent:YES];
@@ -132,7 +144,18 @@ void AWindow::maximize() {
 }
 
 glm::ivec2 AWindow::getWindowPosition() const {
-    return {0, 0};
+    if (!mHandle) return {0, 0};
+    auto* s = static_cast<NSWindow*>(mHandle);
+    const NSRect frame = [s frame];
+    NSScreen* primary = [[NSScreen screens] firstObject];
+    if (!primary) return {0, 0};
+    const CGFloat primaryH = [primary frame].size.height;
+    const float dpi = float([s backingScaleFactor]);
+    // AppKit stores frames in points with bottom-left origin; AUI wants physical-pixel
+    // top-left origin relative to the primary display.
+    const int x = int(frame.origin.x * dpi);
+    const int y = int((primaryH - (frame.origin.y + frame.size.height)) * dpi);
+    return {x, y};
 }
 
 
@@ -155,6 +178,19 @@ void AWindow::setSize(glm::ivec2 size) {
 void AWindow::setGeometry(int x, int y, int width, int height) {
     AViewContainer::setPosition({x, y});
     AViewContainer::setSize({width, height});
+    if (!mHandle) return;
+    auto* s = static_cast<NSWindow*>(mHandle);
+    NSScreen* primary = [[NSScreen screens] firstObject];
+    if (!primary) return;
+    const CGFloat primaryH = [primary frame].size.height;
+    const float dpi = getDpiRatio();
+    // Flip AUI top-left origin back to AppKit bottom-left for setFrame.
+    const NSRect frame = NSMakeRect(
+        x / dpi,
+        primaryH - (y + height) / dpi,
+        width / dpi,
+        height / dpi);
+    [s setFrame:frame display:YES];
 }
 
 glm::ivec2 AWindow::mapPosition(const glm::ivec2& position) {

--- a/aui.views/src/AUI/Platform/macos/AWindowsImpl.mm
+++ b/aui.views/src/AUI/Platform/macos/AWindowsImpl.mm
@@ -82,15 +82,18 @@ void AWindow::show() {
 void AWindow::setWindowStyle(WindowStyle ws) {
     mWindowStyle = ws;
     if (!mHandle) return;
-    if (!!(ws & (WindowStyle::SYS | WindowStyle::NO_DECORATORS))) {
+    const bool hideChrome = !!(ws & (WindowStyle::SYS | WindowStyle::NO_DECORATORS));
+    const bool customTitlebar = !!(ws & WindowStyle::NO_TITLEBAR);
+    if (hideChrome || customTitlebar) {
         auto s = static_cast<NSWindow*>(mHandle);
         [s setStyleMask:([s styleMask] | NSWindowStyleMaskFullSizeContentView)];
         [s setTitlebarAppearsTransparent:YES];
         [s setTitleVisibility:NSWindowTitleHidden];
         [s setMovableByWindowBackground:YES];
-        [[s standardWindowButton:NSWindowCloseButton] setHidden:YES];
-        [[s standardWindowButton:NSWindowMiniaturizeButton] setHidden:YES];
-        [[s standardWindowButton:NSWindowZoomButton] setHidden:YES];
+        const BOOL hideButtons = hideChrome ? YES : NO;
+        [[s standardWindowButton:NSWindowCloseButton] setHidden:hideButtons];
+        [[s standardWindowButton:NSWindowMiniaturizeButton] setHidden:hideButtons];
+        [[s standardWindowButton:NSWindowZoomButton] setHidden:hideButtons];
     }
 }
 

--- a/aui.views/src/AUI/Platform/macos/AWindowsImpl.mm
+++ b/aui.views/src/AUI/Platform/macos/AWindowsImpl.mm
@@ -83,12 +83,14 @@ void AWindow::setWindowStyle(WindowStyle ws) {
     mWindowStyle = ws;
     if (!mHandle) return;
     if (!!(ws & (WindowStyle::SYS | WindowStyle::NO_DECORATORS))) {
-    /*
-        breaks text input and looks poor
         auto s = static_cast<NSWindow*>(mHandle);
-        [s setStyleMask:NSWindowStyleMaskBorderless];
+        [s setStyleMask:([s styleMask] | NSWindowStyleMaskFullSizeContentView)];
         [s setTitlebarAppearsTransparent:YES];
-        [s setTitleVisibility:NSWindowTitleHidden];*/
+        [s setTitleVisibility:NSWindowTitleHidden];
+        [s setMovableByWindowBackground:YES];
+        [[s standardWindowButton:NSWindowCloseButton] setHidden:YES];
+        [[s standardWindowButton:NSWindowMiniaturizeButton] setHidden:YES];
+        [[s standardWindowButton:NSWindowZoomButton] setHidden:YES];
     }
 }
 

--- a/aui.views/src/AUI/Platform/macos/AWindowsImpl.mm
+++ b/aui.views/src/AUI/Platform/macos/AWindowsImpl.mm
@@ -85,8 +85,9 @@ void AWindow::setWindowStyle(WindowStyle ws) {
     const bool hideChrome = !!(ws & (WindowStyle::SYS | WindowStyle::NO_DECORATORS));
     const bool customTitlebar = !!(ws & WindowStyle::NO_TITLEBAR);
     const bool hideMinMax = !!(ws & WindowStyle::NO_MINIMIZE_MAXIMIZE);
+    const bool noResize = !!(ws & WindowStyle::NO_RESIZE);
+    auto s = static_cast<NSWindow*>(mHandle);
     if (hideChrome || customTitlebar) {
-        auto s = static_cast<NSWindow*>(mHandle);
         [s setStyleMask:([s styleMask] | NSWindowStyleMaskFullSizeContentView)];
         [s setTitlebarAppearsTransparent:YES];
         [s setTitleVisibility:NSWindowTitleHidden];
@@ -96,6 +97,14 @@ void AWindow::setWindowStyle(WindowStyle ws) {
         [[s standardWindowButton:NSWindowMiniaturizeButton] setHidden:(hideButtons || hideMinMax)];
         [[s standardWindowButton:NSWindowZoomButton] setHidden:(hideButtons || hideMinMax)];
     }
+
+    NSWindowStyleMask mask = [s styleMask];
+    if (noResize) {
+        mask &= ~NSWindowStyleMaskResizable;
+    } else {
+        mask |= NSWindowStyleMaskResizable;
+    }
+    [s setStyleMask:mask];
 }
 
 float AWindow::fetchDpiFromSystem() const {

--- a/aui.views/src/AUI/Platform/macos/AWindowsImpl.mm
+++ b/aui.views/src/AUI/Platform/macos/AWindowsImpl.mm
@@ -84,6 +84,7 @@ void AWindow::setWindowStyle(WindowStyle ws) {
     if (!mHandle) return;
     const bool hideChrome = !!(ws & (WindowStyle::SYS | WindowStyle::NO_DECORATORS));
     const bool customTitlebar = !!(ws & WindowStyle::NO_TITLEBAR);
+    const bool hideMinMax = !!(ws & WindowStyle::NO_MINIMIZE_MAXIMIZE);
     if (hideChrome || customTitlebar) {
         auto s = static_cast<NSWindow*>(mHandle);
         [s setStyleMask:([s styleMask] | NSWindowStyleMaskFullSizeContentView)];
@@ -92,8 +93,8 @@ void AWindow::setWindowStyle(WindowStyle ws) {
         [s setMovableByWindowBackground:YES];
         const BOOL hideButtons = hideChrome ? YES : NO;
         [[s standardWindowButton:NSWindowCloseButton] setHidden:hideButtons];
-        [[s standardWindowButton:NSWindowMiniaturizeButton] setHidden:hideButtons];
-        [[s standardWindowButton:NSWindowZoomButton] setHidden:hideButtons];
+        [[s standardWindowButton:NSWindowMiniaturizeButton] setHidden:(hideButtons || hideMinMax)];
+        [[s standardWindowButton:NSWindowZoomButton] setHidden:(hideButtons || hideMinMax)];
     }
 }
 

--- a/aui.views/src/AUI/Platform/macos/AWindowsImpl.mm
+++ b/aui.views/src/AUI/Platform/macos/AWindowsImpl.mm
@@ -235,7 +235,29 @@ void AWindow::hideTouchscreenKeyboardImpl() {
 }
 
 void AWindow::moveToCenter() {
+    if (!mHandle) return;
+    auto* s = static_cast<NSWindow*>(mHandle);
+    NSScreen* screen = [s screen];
+    if (!screen) {
+        screen = [[NSScreen screens] firstObject];
+    }
+    if (!screen) return;
 
+    const NSRect screenFrame = [screen frame];
+    const float dpi = getDpiRatio();
+    const glm::ivec2 windowSize = getSize();
+
+    // Mathematical center in points
+    const CGFloat centerX = screenFrame.origin.x + (screenFrame.size.width - windowSize.x / dpi) / 2;
+    const CGFloat centerY = screenFrame.origin.y + (screenFrame.size.height - windowSize.y / dpi) / 2;
+
+    // Convert to AUI coordinates
+    NSScreen* primary = [[NSScreen screens] firstObject];
+    const CGFloat primaryH = [primary frame].size.height;
+    const int auiX = int(centerX * dpi);
+    const int auiY = int((primaryH - (centerY + windowSize.y / dpi)) * dpi);
+
+    setPosition({auiX, auiY});
 }
 
 void AWindow::setMobileScreenOrientation(AScreenOrientation screenOrientation) {

--- a/aui.views/src/AUI/Platform/macos/AWindowsImpl.mm
+++ b/aui.views/src/AUI/Platform/macos/AWindowsImpl.mm
@@ -247,11 +247,9 @@ void AWindow::moveToCenter() {
     const float dpi = getDpiRatio();
     const glm::ivec2 windowSize = getSize();
 
-    // Mathematical center in points
     const CGFloat centerX = screenFrame.origin.x + (screenFrame.size.width - windowSize.x / dpi) / 2;
     const CGFloat centerY = screenFrame.origin.y + (screenFrame.size.height - windowSize.y / dpi) / 2;
 
-    // Convert to AUI coordinates
     NSScreen* primary = [[NSScreen screens] firstObject];
     const CGFloat primaryH = [primary frame].size.height;
     const int auiX = int(centerX * dpi);

--- a/aui.views/src/AUI/Platform/macos/CustomCaptionWindowImplMacos.cpp
+++ b/aui.views/src/AUI/Platform/macos/CustomCaptionWindowImplMacos.cpp
@@ -1,0 +1,50 @@
+/*
+ * AUI Framework - Declarative UI toolkit for modern C++20
+ * Copyright (C) 2020-2025 Alex2772 and Contributors
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "CustomCaptionWindowImplMacos.h"
+#include "AUI/Platform/AWindow.h"
+#include "AUI/Util/UIBuildingHelpers.h"
+#include "AUI/Enum/WindowStyle.h"
+#include <AUI/View/ASpacerFixed.h>
+
+void CustomCaptionWindowImplMacos::initCustomCaption(const AString& name, bool stacked, AViewContainer* to) {
+    auto caption = _new<AViewContainer>();
+    caption->setLayout(std::make_unique<AHorizontalLayout>());
+    caption->addAssName(".window-title");
+    caption->setExpanding({ 1, 0 });
+    caption->setFixedSize({ 0, 28_dp });
+
+    caption->addView(_new<ASpacerFixed>(80_dp));
+
+    mCaptionContainer = _new<AViewContainer>();
+    mCaptionContainer->setLayout(std::make_unique<AHorizontalLayout>());
+    mCaptionContainer->setExpanding({ 1, 0 });
+    mCaptionContainer->addAssName(".window-title-content");
+    caption->addView(mCaptionContainer);
+
+    if (auto* window = dynamic_cast<AWindow*>(to)) {
+        window->setWindowStyle(window->windowStyle() | WindowStyle::NO_TITLEBAR);
+    }
+
+    if (stacked) {
+        to->setLayout(std::make_unique<AStackedLayout>());
+        to->addView(mContentContainer = _new<AViewContainer>());
+        to->addView(declarative::Vertical {
+            caption,
+            _new<ASpacerExpanding>(),
+        } AUI_LET { it->setExpanding({ 1, 1 }); });
+    } else {
+        to->setLayout(std::make_unique<AVerticalLayout>());
+        to->addView(caption);
+        to->addView(mContentContainer = _new<AViewContainer>());
+    }
+    mContentContainer->setExpanding({ 1, 1 });
+}

--- a/aui.views/src/AUI/Platform/macos/CustomCaptionWindowImplMacos.cpp
+++ b/aui.views/src/AUI/Platform/macos/CustomCaptionWindowImplMacos.cpp
@@ -24,6 +24,9 @@ void CustomCaptionWindowImplMacos::initCustomCaption(const AString& name, bool s
 
     caption->addView(_new<ASpacerFixed>(80_dp));
 
+    auto titleLabel = _new<ALabel>(name) << ".title";
+    caption->addView(titleLabel);
+
     mCaptionContainer = _new<AViewContainer>();
     mCaptionContainer->setLayout(std::make_unique<AHorizontalLayout>());
     mCaptionContainer->setExpanding({ 1, 0 });

--- a/aui.views/src/AUI/Platform/macos/CustomCaptionWindowImplMacos.cpp
+++ b/aui.views/src/AUI/Platform/macos/CustomCaptionWindowImplMacos.cpp
@@ -30,10 +30,6 @@ void CustomCaptionWindowImplMacos::initCustomCaption(const AString& name, bool s
     mCaptionContainer->addAssName(".window-title-content");
     caption->addView(mCaptionContainer);
 
-    if (auto* window = dynamic_cast<AWindow*>(to)) {
-        window->setWindowStyle(window->windowStyle() | WindowStyle::NO_TITLEBAR);
-    }
-
     if (stacked) {
         to->setLayout(std::make_unique<AStackedLayout>());
         to->addView(mContentContainer = _new<AViewContainer>());

--- a/aui.views/src/AUI/Platform/macos/CustomCaptionWindowImplMacos.cpp
+++ b/aui.views/src/AUI/Platform/macos/CustomCaptionWindowImplMacos.cpp
@@ -22,7 +22,13 @@ void CustomCaptionWindowImplMacos::initCustomCaption(const AString& name, bool s
     caption->setExpanding({ 1, 0 });
     caption->setFixedSize({ 0, 28_dp });
 
-    caption->addView(_new<ASpacerFixed>(80_dp));
+    const bool minMaxHidden = [&] {
+        if (auto* window = dynamic_cast<AWindow*>(to)) {
+            return !!(window->windowStyle() & WindowStyle::NO_MINIMIZE_MAXIMIZE);
+        }
+        return false;
+    }();
+    caption->addView(_new<ASpacerFixed>(minMaxHidden ? 24_dp : 80_dp));
 
     auto titleLabel = _new<ALabel>(name) << ".title";
     caption->addView(titleLabel);

--- a/aui.views/src/AUI/Platform/macos/CustomCaptionWindowImplMacos.h
+++ b/aui.views/src/AUI/Platform/macos/CustomCaptionWindowImplMacos.h
@@ -1,0 +1,48 @@
+/*
+ * AUI Framework - Declarative UI toolkit for modern C++20
+ * Copyright (C) 2020-2025 Alex2772 and Contributors
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <AUI/View/AViewContainer.h>
+#include <AUI/View/AButton.h>
+
+class ACustomCaptionWindow;
+
+/**
+ * @brief macOS caption implementation — delegates caption controls to AppKit's traffic lights.
+ *
+ * AppKit draws and manages the close/minimize/zoom buttons natively when the window uses
+ * NSWindowStyleMaskFullSizeContentView with a transparent titlebar. This impl therefore does
+ * not create any AUI-side buttons; instead it reserves horizontal space on the left of the
+ * caption container so user content is not covered by the traffic lights.
+ *
+ * The reserved width matches Apple HIG guidance for the default traffic-light layout.
+ */
+class API_AUI_VIEWS CustomCaptionWindowImplMacos {
+protected:
+    _<AViewContainer> mCaptionContainer;
+    _<AViewContainer> mContentContainer;
+
+    // The following members are intentionally null on macOS — traffic lights are native.
+    // They exist to preserve the protected contract expected by ACustomCaptionWindow.
+    _<AButton> mMinimizeButton;
+    _<AButton> mMiddleButton;
+    _<AButton> mCloseButton;
+
+    void updateMiddleButtonIcon() {}
+    void initCustomCaption(const AString& name, bool stacked, AViewContainer* to);
+
+    virtual bool isCustomCaptionMaximized() = 0;
+
+public:
+    CustomCaptionWindowImplMacos() = default;
+    virtual ~CustomCaptionWindowImplMacos() = default;
+};

--- a/aui.views/src/AUI/Platform/macos/MacOSMenuProvider.h
+++ b/aui.views/src/AUI/Platform/macos/MacOSMenuProvider.h
@@ -1,0 +1,39 @@
+/*
+ * AUI Framework - Declarative UI toolkit for modern C++20
+ * Copyright (C) 2020-2025 Alex2772 and Contributors
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <AUI/Action/MenuProvider/IMenuProvider.h>
+
+/**
+ * @brief Native macOS context-menu provider.
+ * @details
+ * Builds an NSMenu tree from an AMenuModel and displays it via
+ * `[NSMenu popUpMenuPositioningItem:atLocation:inView:]`. Gives AppKit's
+ * native appearance, key-equivalents, VoiceOver integration, and system
+ * translucency.
+ */
+class API_AUI_VIEWS MacOSMenuProvider : public IMenuProvider {
+public:
+    MacOSMenuProvider();
+    ~MacOSMenuProvider() override;
+
+    void createMenu(const AVector<AMenuItem>& vector) override;
+    void closeMenu() override;
+    bool isOpen() override;
+
+private:
+    // Opaque pointers to Objective-C objects (NSMenu*, NSMutableArray*). The headers
+    // stay C++-only so non-.mm translation units can include this.
+    void* mCurrentMenu = nullptr;
+    void* mTrampolines = nullptr;
+    bool mOpen = false;
+};

--- a/aui.views/src/AUI/Platform/macos/MacOSMenuProvider.mm
+++ b/aui.views/src/AUI/Platform/macos/MacOSMenuProvider.mm
@@ -1,0 +1,201 @@
+/*
+ * AUI Framework - Declarative UI toolkit for modern C++20
+ * Copyright (C) 2020-2025 Alex2772 and Contributors
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "MacOSMenuProvider.h"
+#include <AUI/Action/AMenu.h>
+#include <AUI/Action/AShortcut.h>
+#include <AUI/Image/IDrawable.h>
+#include <AUI/Image/AImage.h>
+#include <AUI/Platform/AInput.h>
+
+#import <Cocoa/Cocoa.h>
+
+#include <functional>
+#include <utility>
+
+namespace {
+
+// Trampoline so an NSMenuItem target/action pair can invoke a std::function.
+}
+
+@interface AUIMenuTarget : NSObject
+- (instancetype)initWithCallback:(std::function<void()>)cb;
+- (void)invoke:(id)sender;
+@end
+
+@implementation AUIMenuTarget {
+    std::function<void()> _cb;
+}
+- (instancetype)initWithCallback:(std::function<void()>)cb {
+    if ((self = [super init])) {
+        _cb = std::move(cb);
+    }
+    return self;
+}
+- (void)invoke:(id)sender {
+    if (_cb) _cb();
+}
+@end
+
+namespace {
+
+NSString* toNs(const AString& s) {
+    const std::string utf8 = s.toStdString();
+    return [[NSString alloc] initWithBytes:utf8.data()
+                                    length:utf8.size()
+                                  encoding:NSUTF8StringEncoding];
+}
+
+// Convert an AShortcut into an NSMenuItem keyEquivalent + modifierMask pair.
+// AUI's shortcut uses Ctrl as the "command" modifier; on macOS we map Ctrl→⌘ for
+// idiomatic menu display. This is best-effort — more exotic keys fall through as
+// no key equivalent (the menu still works via the stored onAction callback).
+void applyShortcut(NSMenuItem* item, const AShortcut& shortcut) {
+    const AString& display = shortcut.toString();
+    if (display.empty()) return;
+
+    // Parse the last character as the key (common pattern: "Ctrl+Shift+S" → 'S').
+    const auto plus = display.rfind('+');
+    const AString keyPart = (plus == AString::NPOS) ? display : display.substr(plus + 1);
+    if (keyPart.empty()) return;
+
+    NSString* keyNs = toNs(keyPart.lowercase());
+    [item setKeyEquivalent:keyNs];
+
+    NSEventModifierFlags mods = 0;
+    if (display.contains("Ctrl"))  mods |= NSEventModifierFlagCommand;
+    if (display.contains("Shift")) mods |= NSEventModifierFlagShift;
+    if (display.contains("Alt"))   mods |= NSEventModifierFlagOption;
+    if (display.contains("Meta"))  mods |= NSEventModifierFlagControl;
+    [item setKeyEquivalentModifierMask:mods];
+}
+
+// Convert an AUI IDrawable to an NSImage suitable for a menu item (16pt nominal).
+// Returns nil on failure; menu will render without an icon in that case.
+NSImage* drawableToNSImage(const _<IDrawable>& drawable) {
+    if (!drawable) return nil;
+    const glm::ivec2 size { 32, 32 };   // 16pt @ 2x for Retina clarity
+    AImage rasterized = drawable->rasterize(size);
+    const auto buf = rasterized.buffer();
+    if (buf.empty()) return nil;
+
+    const int w = rasterized.width();
+    const int h = rasterized.height();
+    const int bytesPerRow = w * 4;
+
+    NSBitmapImageRep* rep = [[NSBitmapImageRep alloc]
+        initWithBitmapDataPlanes:nullptr
+                      pixelsWide:w
+                      pixelsHigh:h
+                   bitsPerSample:8
+                 samplesPerPixel:4
+                        hasAlpha:YES
+                        isPlanar:NO
+                  colorSpaceName:NSDeviceRGBColorSpace
+                     bytesPerRow:bytesPerRow
+                    bitsPerPixel:32];
+    if (!rep) return nil;
+    if (int(buf.size()) < bytesPerRow * h) return nil;
+    std::memcpy([rep bitmapData], buf.data(), bytesPerRow * h);
+
+    NSImage* image = [[NSImage alloc] initWithSize:NSMakeSize(16, 16)];
+    [image addRepresentation:rep];
+    [image setTemplate:NO];
+    return image;
+}
+
+NSMenu* buildMenu(const AVector<AMenuItem>& items, NSMutableArray* keepAlive) {
+    NSMenu* menu = [[NSMenu alloc] init];
+    [menu setAutoenablesItems:NO];
+
+    for (const auto& item : items) {
+        switch (item.type) {
+            case AMenu::SEPARATOR: {
+                [menu addItem:[NSMenuItem separatorItem]];
+                break;
+            }
+            case AMenu::SUBLIST: {
+                NSMenuItem* mi = [[NSMenuItem alloc] initWithTitle:toNs(item.name)
+                                                            action:nil
+                                                     keyEquivalent:@""];
+                [mi setSubmenu:buildMenu(item.subItems, keepAlive)];
+                [mi setEnabled:item.enabled];
+                if (NSImage* icon = drawableToNSImage(item.icon)) {
+                    [mi setImage:icon];
+                }
+                [menu addItem:mi];
+                break;
+            }
+            case AMenu::SINGLE: {
+                AUIMenuTarget* tgt = [[AUIMenuTarget alloc] initWithCallback:item.onAction];
+                [keepAlive addObject:tgt];
+
+                NSMenuItem* mi = [[NSMenuItem alloc] initWithTitle:toNs(item.name)
+                                                            action:@selector(invoke:)
+                                                     keyEquivalent:@""];
+                [mi setTarget:tgt];
+                [mi setEnabled:item.enabled];
+                applyShortcut(mi, item.shortcut);
+                if (NSImage* icon = drawableToNSImage(item.icon)) {
+                    [mi setImage:icon];
+                }
+                [menu addItem:mi];
+                break;
+            }
+        }
+    }
+    return menu;
+}
+
+}   // namespace
+
+MacOSMenuProvider::MacOSMenuProvider() = default;
+
+MacOSMenuProvider::~MacOSMenuProvider() {
+    closeMenu();
+}
+
+void MacOSMenuProvider::createMenu(const AVector<AMenuItem>& vector) {
+    closeMenu();
+
+    NSMutableArray* keepAlive = [[NSMutableArray alloc] init];
+    NSMenu* menu = buildMenu(vector, keepAlive);
+
+    // Retain both objects across the modal tracking loop; release after popUp returns.
+    mTrampolines = (__bridge_retained void*) keepAlive;
+    mCurrentMenu = (__bridge_retained void*) menu;
+
+    mOpen = true;
+    const NSPoint loc = [NSEvent mouseLocation];   // screen coords (bottom-left origin)
+    [menu popUpMenuPositioningItem:nil atLocation:loc inView:nil];
+    mOpen = false;
+
+    if (mCurrentMenu) {
+        CFRelease(mCurrentMenu);
+        mCurrentMenu = nullptr;
+    }
+    if (mTrampolines) {
+        CFRelease(mTrampolines);
+        mTrampolines = nullptr;
+    }
+}
+
+void MacOSMenuProvider::closeMenu() {
+    if (!mCurrentMenu) return;
+    NSMenu* menu = (__bridge NSMenu*) mCurrentMenu;
+    [menu cancelTracking];
+    // `popUpMenuPositioningItem` is modal; cancelTracking unblocks it and the release
+    // happens on the return path from createMenu.
+}
+
+bool MacOSMenuProvider::isOpen() {
+    return mOpen;
+}

--- a/aui.views/src/AUI/Platform/macos/MacOSMenuProvider.mm
+++ b/aui.views/src/AUI/Platform/macos/MacOSMenuProvider.mm
@@ -47,11 +47,14 @@ namespace {
 
 namespace {
 
+// Returns an autoreleased NSString so it can be used inline in +alloc/-init calls
+// (the receiving AppKit method will copy/retain as needed, and we don't leak +1).
 NSString* toNs(const AString& s) {
     const std::string utf8 = s.toStdString();
-    return [[NSString alloc] initWithBytes:utf8.data()
-                                    length:utf8.size()
-                                  encoding:NSUTF8StringEncoding];
+    NSString* str = [[NSString alloc] initWithBytes:utf8.data()
+                                             length:utf8.size()
+                                           encoding:NSUTF8StringEncoding];
+    return [str autorelease];
 }
 
 // Convert an AShortcut into an NSMenuItem keyEquivalent + modifierMask pair.
@@ -59,12 +62,18 @@ NSString* toNs(const AString& s) {
 // idiomatic menu display. This is best-effort — more exotic keys fall through as
 // no key equivalent (the menu still works via the stored onAction callback).
 void applyShortcut(NSMenuItem* item, const AShortcut& shortcut) {
-    const AString& display = shortcut.toString();
+    if (shortcut.empty()) return;
+    const AString display = static_cast<AString>(shortcut);
     if (display.empty()) return;
 
     // Parse the last character as the key (common pattern: "Ctrl+Shift+S" → 'S').
     const auto plus = display.rfind('+');
-    const AString keyPart = (plus == AString::NPOS) ? display : display.substr(plus + 1);
+    AString keyPart;
+    if (plus == AString::NPOS) {
+        keyPart = display;
+    } else {
+        keyPart = display.substr(plus + 1);
+    }
     if (keyPart.empty()) return;
 
     NSString* keyNs = toNs(keyPart.lowercase());
@@ -103,56 +112,68 @@ NSImage* drawableToNSImage(const _<IDrawable>& drawable) {
                      bytesPerRow:bytesPerRow
                     bitsPerPixel:32];
     if (!rep) return nil;
-    if (int(buf.size()) < bytesPerRow * h) return nil;
+    if (int(buf.size()) < bytesPerRow * h) {
+        [rep release];
+        return nil;
+    }
     std::memcpy([rep bitmapData], buf.data(), bytesPerRow * h);
 
-    NSImage* image = [[NSImage alloc] initWithSize:NSMakeSize(16, 16)];
-    [image addRepresentation:rep];
+    NSImage* image = [[NSImage alloc] initWithSize:NSMakeSize(16, 16)];   // +1, caller owns
+    [image addRepresentation:rep];                                        // rep now +2 (image retains)
+    [rep release];                                                        // back to +1 owned by image
     [image setTemplate:NO];
     return image;
 }
 
 NSMenu* buildMenu(const AVector<AMenuItem>& items, NSMutableArray* keepAlive) {
-    NSMenu* menu = [[NSMenu alloc] init];
+    NSMenu* menu = [[NSMenu alloc] init];   // +1, caller owns
     [menu setAutoenablesItems:NO];
 
     for (const auto& item : items) {
         switch (item.type) {
             case AMenu::SEPARATOR: {
+                // `separatorItem` returns an autoreleased object; addItem retains.
                 [menu addItem:[NSMenuItem separatorItem]];
                 break;
             }
             case AMenu::SUBLIST: {
                 NSMenuItem* mi = [[NSMenuItem alloc] initWithTitle:toNs(item.name)
                                                             action:nil
-                                                     keyEquivalent:@""];
-                [mi setSubmenu:buildMenu(item.subItems, keepAlive)];
+                                                     keyEquivalent:@""];   // +1
+                NSMenu* sub = buildMenu(item.subItems, keepAlive);        // +1
+                [mi setSubmenu:sub];                                      // retain
+                [sub release];                                            // back to +1 owned by mi
                 [mi setEnabled:item.enabled];
                 if (NSImage* icon = drawableToNSImage(item.icon)) {
                     [mi setImage:icon];
+                    [icon release];                                       // setImage retains
                 }
-                [menu addItem:mi];
+                [menu addItem:mi];                                        // retain
+                [mi release];                                             // back to +1 owned by menu
                 break;
             }
             case AMenu::SINGLE: {
-                AUIMenuTarget* tgt = [[AUIMenuTarget alloc] initWithCallback:item.onAction];
-                [keepAlive addObject:tgt];
+                AUIMenuTarget* tgt = [[AUIMenuTarget alloc] initWithCallback:item.onAction]; // +1
+                [keepAlive addObject:tgt];                                                    // retain
+                [tgt release];                                                                // +1 owned by keepAlive
 
                 NSMenuItem* mi = [[NSMenuItem alloc] initWithTitle:toNs(item.name)
                                                             action:@selector(invoke:)
-                                                     keyEquivalent:@""];
+                                                     keyEquivalent:@""];   // +1
                 [mi setTarget:tgt];
                 [mi setEnabled:item.enabled];
                 applyShortcut(mi, item.shortcut);
                 if (NSImage* icon = drawableToNSImage(item.icon)) {
                     [mi setImage:icon];
+                    [icon release];
                 }
                 [menu addItem:mi];
+                [mi release];
                 break;
             }
         }
     }
-    return menu;
+    return menu;   // caller owns (+1)
 }
 
 }   // namespace
@@ -169,9 +190,11 @@ void MacOSMenuProvider::createMenu(const AVector<AMenuItem>& vector) {
     NSMutableArray* keepAlive = [[NSMutableArray alloc] init];
     NSMenu* menu = buildMenu(vector, keepAlive);
 
-    // Retain both objects across the modal tracking loop; release after popUp returns.
-    mTrampolines = (__bridge_retained void*) keepAlive;
-    mCurrentMenu = (__bridge_retained void*) menu;
+    // Non-ARC: the alloc/init above leaves both objects at retain count 1. Store as
+    // raw void* (no bridge casts — ARC is off in this translation unit) and manually
+    // release after the modal tracking loop returns.
+    mTrampolines = (void*) keepAlive;
+    mCurrentMenu = (void*) menu;
 
     mOpen = true;
     const NSPoint loc = [NSEvent mouseLocation];   // screen coords (bottom-left origin)
@@ -179,18 +202,18 @@ void MacOSMenuProvider::createMenu(const AVector<AMenuItem>& vector) {
     mOpen = false;
 
     if (mCurrentMenu) {
-        CFRelease(mCurrentMenu);
+        [(id) mCurrentMenu release];
         mCurrentMenu = nullptr;
     }
     if (mTrampolines) {
-        CFRelease(mTrampolines);
+        [(id) mTrampolines release];
         mTrampolines = nullptr;
     }
 }
 
 void MacOSMenuProvider::closeMenu() {
     if (!mCurrentMenu) return;
-    NSMenu* menu = (__bridge NSMenu*) mCurrentMenu;
+    NSMenu* menu = (NSMenu*) mCurrentMenu;
     [menu cancelTracking];
     // `popUpMenuPositioningItem` is modal; cancelTracking unblocks it and the release
     // happens on the return path from createMenu.

--- a/aui.views/src/AUI/Platform/macos/MacOSMenuProvider.mm
+++ b/aui.views/src/AUI/Platform/macos/MacOSMenuProvider.mm
@@ -121,7 +121,7 @@ NSImage* drawableToNSImage(const _<IDrawable>& drawable) {
     NSImage* image = [[NSImage alloc] initWithSize:NSMakeSize(16, 16)];   // +1, caller owns
     [image addRepresentation:rep];                                        // rep now +2 (image retains)
     [rep release];                                                        // back to +1 owned by image
-    [image setTemplate:NO];
+    [image setTemplate:YES];
     return image;
 }
 

--- a/aui.views/src/AUI/Platform/macos/MacOSMenuProvider.mm
+++ b/aui.views/src/AUI/Platform/macos/MacOSMenuProvider.mm
@@ -21,11 +21,7 @@
 #include <functional>
 #include <utility>
 
-namespace {
-
 // Trampoline so an NSMenuItem target/action pair can invoke a std::function.
-}
-
 @interface AUIMenuTarget : NSObject
 - (instancetype)initWithCallback:(std::function<void()>)cb;
 - (void)invoke:(id)sender;
@@ -67,6 +63,8 @@ void applyShortcut(NSMenuItem* item, const AShortcut& shortcut) {
     if (display.empty()) return;
 
     // Parse the last character as the key (common pattern: "Ctrl+Shift+S" → 'S').
+    // The if/else avoids an AString/AStringView conversion ambiguity that fires when
+    // `display` and `display.substr(...)` are mixed in a ternary.
     const auto plus = display.rfind('+');
     AString keyPart;
     if (plus == AString::NPOS) {
@@ -118,15 +116,18 @@ NSImage* drawableToNSImage(const _<IDrawable>& drawable) {
     }
     std::memcpy([rep bitmapData], buf.data(), bytesPerRow * h);
 
-    NSImage* image = [[NSImage alloc] initWithSize:NSMakeSize(16, 16)];   // +1, caller owns
-    [image addRepresentation:rep];                                        // rep now +2 (image retains)
-    [rep release];                                                        // back to +1 owned by image
+    NSImage* image = [[NSImage alloc] initWithSize:NSMakeSize(16, 16)];
+    [image addRepresentation:rep];
+    [rep release];
     [image setTemplate:YES];
     return image;
 }
 
 NSMenu* buildMenu(const AVector<AMenuItem>& items, NSMutableArray* keepAlive) {
-    NSMenu* menu = [[NSMenu alloc] init];   // +1, caller owns
+    // MRR ownership: every NSObject we alloc here is at +1 (we own it). After handing off
+    // to a parent collection (NSMenu / NSMutableArray) that retains, we drop our +1 with
+    // release. The root NSMenu is returned to the caller at +1.
+    NSMenu* menu = [[NSMenu alloc] init];
     [menu setAutoenablesItems:NO];
 
     for (const auto& item : items) {
@@ -139,27 +140,27 @@ NSMenu* buildMenu(const AVector<AMenuItem>& items, NSMutableArray* keepAlive) {
             case AMenu::SUBLIST: {
                 NSMenuItem* mi = [[NSMenuItem alloc] initWithTitle:toNs(item.name)
                                                             action:nil
-                                                     keyEquivalent:@""];   // +1
-                NSMenu* sub = buildMenu(item.subItems, keepAlive);        // +1
-                [mi setSubmenu:sub];                                      // retain
-                [sub release];                                            // back to +1 owned by mi
+                                                     keyEquivalent:@""];
+                NSMenu* sub = buildMenu(item.subItems, keepAlive);
+                [mi setSubmenu:sub];
+                [sub release];
                 [mi setEnabled:item.enabled];
                 if (NSImage* icon = drawableToNSImage(item.icon)) {
                     [mi setImage:icon];
-                    [icon release];                                       // setImage retains
+                    [icon release];
                 }
-                [menu addItem:mi];                                        // retain
-                [mi release];                                             // back to +1 owned by menu
+                [menu addItem:mi];
+                [mi release];
                 break;
             }
             case AMenu::SINGLE: {
-                AUIMenuTarget* tgt = [[AUIMenuTarget alloc] initWithCallback:item.onAction]; // +1
-                [keepAlive addObject:tgt];                                                    // retain
-                [tgt release];                                                                // +1 owned by keepAlive
+                AUIMenuTarget* tgt = [[AUIMenuTarget alloc] initWithCallback:item.onAction];
+                [keepAlive addObject:tgt];
+                [tgt release];
 
                 NSMenuItem* mi = [[NSMenuItem alloc] initWithTitle:toNs(item.name)
                                                             action:@selector(invoke:)
-                                                     keyEquivalent:@""];   // +1
+                                                     keyEquivalent:@""];
                 [mi setTarget:tgt];
                 [mi setEnabled:item.enabled];
                 applyShortcut(mi, item.shortcut);
@@ -173,7 +174,7 @@ NSMenu* buildMenu(const AVector<AMenuItem>& items, NSMutableArray* keepAlive) {
             }
         }
     }
-    return menu;   // caller owns (+1)
+    return menu;
 }
 
 }   // namespace

--- a/aui.views/src/AUI/Platform/win32/ACustomWindowImpl.cpp
+++ b/aui.views/src/AUI/Platform/win32/ACustomWindowImpl.cpp
@@ -230,7 +230,7 @@ void ACustomWindow::doDrawWindow()
     AWindow::doDrawWindow();
 }
 
-ACustomWindow::ACustomWindow(const AString& name, int width, int height, AWindow* parent): AWindow(nullptr)
+ACustomWindow::ACustomWindow(const AString& name, AMetric width, AMetric height, AWindow* parent): AWindow(nullptr)
 {
     // init here to be sure vtable for wndProc for WM_CREATE is initialized
     windowNativePreInit(name, width, height, parent, WindowStyle::DEFAULT);

--- a/aui.views/src/AUI/Platform/win32/ACustomWindowImpl.cpp
+++ b/aui.views/src/AUI/Platform/win32/ACustomWindowImpl.cpp
@@ -157,8 +157,10 @@ LRESULT ACustomWindow::winProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPara
                 result = HTCAPTION;
             }
         }
-        if (result)
+        if (result) {
             return result;
+        }
+        return AWindow::winProc(hwnd, uMsg, wParam, lParam);
     } //end case WM_NCHITTEST
 
     case WM_NCMOUSEMOVE: {

--- a/aui.views/src/AUI/Platform/win32/ACustomWindowImpl.cpp
+++ b/aui.views/src/AUI/Platform/win32/ACustomWindowImpl.cpp
@@ -10,6 +10,8 @@
  */
 
 #include "AUI/Platform/ACustomWindow.h"
+#include "AUI/Platform/ACustomCaptionWindow.h"
+#include "AUI/Platform/win32/CustomCaptionWindowImplWin32.h"
 #include "AUI/Platform/ADesktop.h"
 #include <cstring>
 #include <AUI/View/AButton.h>
@@ -32,7 +34,9 @@ LRESULT ACustomWindow::winProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPara
     {
         case WM_CREATE: {
             updateDpi();
-            const MARGINS shadow = {1, 1, 1, 1};
+            const int captionTop = GetSystemMetrics(SM_CYCAPTION) +
+                                   GetSystemMetrics(SM_CXPADDEDBORDER);
+            const MARGINS shadow = { 0, 0, captionTop, 0 };
             DwmExtendFrameIntoClientArea((HWND) getNativeHandle(), &shadow);
 
             // update window size
@@ -78,6 +82,17 @@ LRESULT ACustomWindow::winProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPara
 
         auto x = GET_X_LPARAM(lParam);
         auto y = GET_Y_LPARAM(lParam);
+
+        // Caption buttons win over the top resize border — otherwise the top 8px of a
+        // min/max/close button would be treated as HTTOP and start a resize drag instead
+        // of registering a button click.
+        if (auto* caption = dynamic_cast<ACustomCaptionWindow*>(this)) {
+            auto* impl = static_cast<CustomCaptionWindowImplWin32*>(caption);
+            const glm::ivec2 localPx { x - winrect.left, y - winrect.top };
+            if (auto hit = impl->hitTestCaptionButton(localPx.x, localPx.y)) {
+                return *hit;
+            }
+        }
 
         bool resizeWidth = !(mWindowStyle & WindowStyle::NO_RESIZE);//window->minimumWidth() != window->maximumWidth();
         bool resizeHeight = resizeWidth;//window->minimumHeight() != window->maximumHeight();
@@ -136,15 +151,69 @@ LRESULT ACustomWindow::winProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lPara
             }
         }
 
-        //TODO: allow move?
         if (!result) {
-            if (isCaptionAt({x - winrect.left, y - winrect.top})) {
+            const glm::ivec2 localPx { x - winrect.left, y - winrect.top };
+            if (isCaptionAt(localPx)) {
                 result = HTCAPTION;
             }
         }
         if (result)
             return result;
     } //end case WM_NCHITTEST
+
+    case WM_NCMOUSEMOVE: {
+        if (auto* caption = dynamic_cast<ACustomCaptionWindow*>(this)) {
+            static_cast<CustomCaptionWindowImplWin32*>(caption)
+                ->updateCaptionButtonNcHover(static_cast<std::int32_t>(wParam));
+            // Register for WM_NCMOUSELEAVE so we can clear hover when cursor exits NC area.
+            TRACKMOUSEEVENT tme {};
+            tme.cbSize = sizeof(tme);
+            tme.hwndTrack = hwnd;
+            tme.dwFlags = TME_LEAVE | TME_NONCLIENT;
+            TrackMouseEvent(&tme);
+        }
+        break;
+    }
+
+    case WM_NCMOUSELEAVE: {
+        if (auto* caption = dynamic_cast<ACustomCaptionWindow*>(this)) {
+            static_cast<CustomCaptionWindowImplWin32*>(caption)->updateCaptionButtonNcHover(0);
+        }
+        break;
+    }
+
+    case WM_NCLBUTTONDOWN: {
+        switch (wParam) {
+            case HTMINBUTTON:
+            case HTMAXBUTTON:
+            case HTCLOSE:
+                return 0;
+        }
+        break;
+    }
+
+    case WM_NCLBUTTONUP: {
+        if (wParam == HTMINBUTTON || wParam == HTMAXBUTTON || wParam == HTCLOSE) {
+            if (auto* caption = dynamic_cast<ACustomCaptionWindow*>(this)) {
+                switch (wParam) {
+                    case HTMINBUTTON:
+                        caption->minimize();
+                        return 0;
+                    case HTMAXBUTTON:
+                        if (caption->isMaximized()) {
+                            caption->restore();
+                        } else {
+                            caption->maximize();
+                        }
+                        return 0;
+                    case HTCLOSE:
+                        caption->quit();
+                        return 0;
+                }
+            }
+        }
+        break;
+    }
 
     }
     return AWindow::winProc(hwnd, uMsg, wParam, lParam);

--- a/aui.views/src/AUI/Platform/win32/AWindowsImpl.cpp
+++ b/aui.views/src/AUI/Platform/win32/AWindowsImpl.cpp
@@ -50,6 +50,7 @@
 #include <AUI/Platform/AMessageBox.h>
 #include <AUI/Platform/win32/AComBase.h>
 #include <AUI/Platform/win32/Theme.h>
+#include <dwmapi.h>
 
 LRESULT AWindow::winProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
 #define GET_X_LPARAM(lp)    ((int)(short)LOWORD(lp))
@@ -95,6 +96,52 @@ LRESULT AWindow::winProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam) {
         case WM_CREATE: // used for ACustomWindow
             updateDpi();
             return 0;
+
+        case WM_NCCALCSIZE: {
+            if (!(mWindowStyle & WindowStyle::NO_TITLEBAR) || wParam == FALSE) {
+                break;
+            }
+            // Collapse the caption strip into the client area while keeping DWM-drawn buttons.
+            auto* params = reinterpret_cast<NCCALCSIZE_PARAMS*>(lParam);
+            const int frameX = GetSystemMetrics(SM_CXFRAME);
+            const int frameY = GetSystemMetrics(SM_CYFRAME);
+            const int padding = GetSystemMetrics(SM_CXPADDEDBORDER);
+            RECT& rc = params->rgrc[0];
+            rc.right -= frameX + padding;
+            rc.left += frameX + padding;
+            rc.bottom -= frameY + padding;
+            if (IsZoomed(hwnd)) {
+                // Maximized windows would otherwise be clipped off-screen by the frame.
+                rc.top += padding;
+            }
+            return 0;
+        }
+
+        case WM_NCHITTEST: {
+            if (!(mWindowStyle & WindowStyle::NO_TITLEBAR)) {
+                break;
+            }
+            // Let DWM claim hits on the min/max/close glyphs it rendered.
+            LRESULT dwmResult = 0;
+            if (DwmDefWindowProc(hwnd, uMsg, wParam, lParam, &dwmResult)) {
+                return dwmResult;
+            }
+            const LRESULT hit = DefWindowProc(hwnd, uMsg, wParam, lParam);
+            if (hit == HTCLIENT) {
+                // Inside the reclaimed caption strip: mark as draggable caption so
+                // the OS handles move/snap layouts. The application is responsible
+                // for reserving space above interactive views so this doesn't swallow
+                // input meant for them.
+                POINT pt { GET_X_LPARAM(lParam), GET_Y_LPARAM(lParam) };
+                ScreenToClient(hwnd, &pt);
+                const int captionHeight = GetSystemMetrics(SM_CYCAPTION) +
+                                          GetSystemMetrics(SM_CXPADDEDBORDER);
+                if (pt.y >= 0 && pt.y < captionHeight) {
+                    return HTCAPTION;
+                }
+            }
+            return hit;
+        }
 
         case WM_USER:
             return 0;
@@ -348,6 +395,23 @@ void AWindow::setWindowStyle(WindowStyle ws) {
             LONG lExStyle = GetWindowLong(mHandle, GWL_EXSTYLE);
             lExStyle &= ~(WS_EX_DLGMODALFRAME | WS_EX_CLIENTEDGE | WS_EX_STATICEDGE);
             SetWindowLong(mHandle, GWL_EXSTYLE, lExStyle);
+            SetWindowPos(mHandle, NULL, 0, 0, 0, 0,
+                         SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOOWNERZORDER);
+        }
+        if (!!(ws & WindowStyle::NO_TITLEBAR)) {
+            // Keep WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX so DWM keeps
+            // rendering the caption buttons; our WM_NCCALCSIZE handler collapses the visible
+            // titlebar into the client area.
+            LONG style = GetWindowLong(mHandle, GWL_STYLE);
+            style |= WS_CAPTION | WS_SYSMENU | WS_MINIMIZEBOX | WS_MAXIMIZEBOX;
+            if (!(ws & WindowStyle::NO_RESIZE)) {
+                style |= WS_THICKFRAME;
+            }
+            SetWindowLongPtr(mHandle, GWL_STYLE, style);
+
+            const MARGINS extend = { 0, 0, 1, 0 };
+            DwmExtendFrameIntoClientArea(mHandle, &extend);
+
             SetWindowPos(mHandle, NULL, 0, 0, 0, 0,
                          SWP_FRAMECHANGED | SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOOWNERZORDER);
         }

--- a/aui.views/src/AUI/Platform/win32/CustomCaptionWindowImplWin32.cpp
+++ b/aui.views/src/AUI/Platform/win32/CustomCaptionWindowImplWin32.cpp
@@ -1,0 +1,117 @@
+/*
+ * AUI Framework - Declarative UI toolkit for modern C++20
+ * Copyright (C) 2020-2025 Alex2772 and Contributors
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//
+// Created by alex2 on 05.12.2020.
+//
+
+#include "CustomCaptionWindowImplWin32.h"
+#include <AUI/Util/UIBuildingHelpers.h>
+#include <AUI/Common/Plugin.h>
+#include <AUI/ASS/Property/BackgroundImage.h>
+
+#include <windows.h>
+
+namespace {
+bool containsPoint(const _<AButton>& button, int px, int py) {
+    if (!button) return false;
+    const auto topLeft = button->getPositionInWindow();
+    const auto size = button->getSize();
+    return px >= topLeft.x && py >= topLeft.y &&
+           px < topLeft.x + size.x && py < topLeft.y + size.y;
+}
+
+constexpr auto kNcHoverClass = ".nc-hover";
+}
+
+void CustomCaptionWindowImplWin32::initCustomCaption(const AString& name, bool stacked, AViewContainer* to) {
+    auto caption = _new<AViewContainer>();
+    caption->setLayout(std::make_unique<AHorizontalLayout>());
+    caption->addAssName(".window-title");
+    caption->setExpanding({1, 0});
+
+    auto titleLabel = _new<ALabel>(name) << ".title";
+    caption->addView(titleLabel);
+
+    mCaptionContainer = _new<AViewContainer>();
+    mCaptionContainer->setLayout(std::make_unique<AHorizontalLayout>());
+    mCaptionContainer->setExpanding({1, 0 });
+    mCaptionContainer->addAssName(".window-title-content");
+    caption->addView(mCaptionContainer);
+
+    mMinimizeButton = _new<AButton>();
+    mMinimizeButton->addAssName(".minimize");
+    mMinimizeButton->addAssName(".default");
+    caption->addView(mMinimizeButton);
+
+    mMiddleButton = _new<AButton>();
+    mMiddleButton->addAssName(".middle");
+    mMiddleButton->addAssName(".default");
+
+    caption->addView(mMiddleButton);
+
+    mCloseButton = _new<AButton>();
+    mCloseButton->addAssName(".close");
+    mCloseButton->addAssName(".default");
+    caption->addView(mCloseButton);
+
+    if (stacked) {
+        to->setLayout(std::make_unique<AStackedLayout>());
+        to->addView(mContentContainer = _new<AViewContainer>());
+        to->addView(declarative::Vertical {
+                                                    caption,
+                                                    _new<ASpacerExpanding>(),
+                                            } AUI_LET { it->setExpanding({1, 1}); });
+    } else {
+        to->setLayout(std::make_unique<AVerticalLayout>());
+        to->addView(caption);
+        to->addView(mContentContainer = _new<AViewContainer>());
+    }
+    mContentContainer->setExpanding({1, 1});
+
+    updateMiddleButtonIcon();
+}
+
+void CustomCaptionWindowImplWin32::updateMiddleButtonIcon() {
+    if (isCustomCaptionMaximized()) {
+        mMiddleButton->setCustomStyle({
+            ass::BackgroundImage {":uni/caption/restore.svg", {}, {}, ass::Sizing::CENTER }
+        });
+    } else {
+        mMiddleButton->setCustomStyle({
+            ass::BackgroundImage {":uni/caption/maximize.svg", {}, {}, ass::Sizing::CENTER }
+        });
+    }
+}
+
+AOptional<std::int32_t> CustomCaptionWindowImplWin32::hitTestCaptionButton(int clientPxX, int clientPxY) const {
+    if (containsPoint(mMinimizeButton, clientPxX, clientPxY)) return HTMINBUTTON;
+    if (containsPoint(mMiddleButton, clientPxX, clientPxY))   return HTMAXBUTTON;
+    if (containsPoint(mCloseButton, clientPxX, clientPxY))    return HTCLOSE;
+    return std::nullopt;
+}
+
+void CustomCaptionWindowImplWin32::updateCaptionButtonNcHover(std::int32_t hitCode) {
+    auto applyHover = [&](const _<AButton>& button, bool active) {
+        if (!button) return;
+        // Toggle the ASS class without disturbing other names the button already carries.
+        const auto& names = button->getAssNames();
+        const bool hasClass = names.contains(kNcHoverClass);
+        if (active && !hasClass) {
+            button->addAssName(kNcHoverClass);
+        } else if (!active && hasClass) {
+            button->removeAssName(kNcHoverClass);
+        }
+    };
+    applyHover(mMinimizeButton, hitCode == HTMINBUTTON);
+    applyHover(mMiddleButton,   hitCode == HTMAXBUTTON);
+    applyHover(mCloseButton,    hitCode == HTCLOSE);
+}

--- a/aui.views/src/AUI/Platform/win32/CustomCaptionWindowImplWin32.cpp
+++ b/aui.views/src/AUI/Platform/win32/CustomCaptionWindowImplWin32.cpp
@@ -14,6 +14,9 @@
 //
 
 #include "CustomCaptionWindowImplWin32.h"
+#include "AUI/Platform/AWindow.h"
+#include "AUI/Enum/WindowStyle.h"
+#include "AUI/Enum/Visibility.h"
 #include <AUI/Util/UIBuildingHelpers.h>
 #include <AUI/Common/Plugin.h>
 #include <AUI/ASS/Property/BackgroundImage.h>
@@ -23,6 +26,7 @@
 namespace {
 bool containsPoint(const _<AButton>& button, int px, int py) {
     if (!button) return false;
+    if (button->getVisibility() == Visibility::GONE) return false;
     const auto topLeft = button->getPositionInWindow();
     const auto size = button->getSize();
     return px >= topLeft.x && py >= topLeft.y &&
@@ -76,6 +80,14 @@ void CustomCaptionWindowImplWin32::initCustomCaption(const AString& name, bool s
         to->addView(mContentContainer = _new<AViewContainer>());
     }
     mContentContainer->setExpanding({1, 1});
+
+    // Hide the minimize/maximize buttons when the window style opts out of them.
+    if (auto* window = dynamic_cast<AWindow*>(to)) {
+        if (!!(window->windowStyle() & WindowStyle::NO_MINIMIZE_MAXIMIZE)) {
+            mMinimizeButton->setVisibility(Visibility::GONE);
+            mMiddleButton->setVisibility(Visibility::GONE);
+        }
+    }
 
     updateMiddleButtonIcon();
 }

--- a/aui.views/src/AUI/Platform/win32/CustomCaptionWindowImplWin32.h
+++ b/aui.views/src/AUI/Platform/win32/CustomCaptionWindowImplWin32.h
@@ -1,0 +1,66 @@
+/*
+ * AUI Framework - Declarative UI toolkit for modern C++20
+ * Copyright (C) 2020-2025 Alex2772 and Contributors
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+//
+// Created by alex2 on 05.12.2020.
+//
+
+#pragma once
+
+#include <AUI/View/AViewContainer.h>
+#include <AUI/View/AButton.h>
+#include <AUI/Common/AOptional.h>
+
+#include <cstdint>
+
+class API_AUI_VIEWS CustomCaptionWindowImplWin32 {
+protected:
+    _<AViewContainer> mCaptionContainer;
+    _<AViewContainer> mContentContainer;
+    _<AButton> mMinimizeButton; // _
+    _<AButton> mMiddleButton; // []
+    _<AButton> mCloseButton; // X
+
+    void updateMiddleButtonIcon();
+    void initCustomCaption(const AString& name, bool stacked, AViewContainer* to);
+
+    virtual bool isCustomCaptionMaximized() = 0;
+
+public:
+    CustomCaptionWindowImplWin32() = default;
+
+    virtual ~CustomCaptionWindowImplWin32() = default;
+
+    /**
+     * @brief Test a client-space point against the caption button rects.
+     * @param clientPxX client-area x in physical pixels (relative to window top-left).
+     * @param clientPxY client-area y in physical pixels.
+     * @return HTMINBUTTON / HTMAXBUTTON / HTCLOSE when the point is over the corresponding
+     *         button, or std::nullopt when the point is outside all three. Returning an HT
+     *         button code from WM_NCHITTEST enables Win11 snap-layout flyouts on hover of
+     *         the maximize button and lets the OS dispatch SC_MINIMIZE/SC_MAXIMIZE/SC_CLOSE
+     *         automatically on click.
+     */
+    AOptional<std::int32_t> hitTestCaptionButton(int clientPxX, int clientPxY) const;
+
+    /**
+     * @brief Sync button hover visuals from WM_NCMOUSEMOVE.
+     *
+     * When WM_NCHITTEST returns an HT button code, the region becomes non-client; AButton
+     * stops receiving WM_MOUSEMOVE and its own hover state freezes. This method reflects
+     * the NC hit result back into the buttons so their rendering tracks the cursor.
+     *
+     * @param hitCode the HT* code reported by the latest WM_NCMOUSEMOVE, or 0 to clear.
+     */
+    void updateCaptionButtonNcHover(std::int32_t hitCode);
+};
+
+

--- a/aui.views/src/AUI/Platform/win32/Win32MenuProvider.cpp
+++ b/aui.views/src/AUI/Platform/win32/Win32MenuProvider.cpp
@@ -116,10 +116,12 @@ void appendItem(HMENU parent, const AMenuItem& item, MenuResources& res) {
 
             // Win32 auto-right-aligns anything after a tab character.
             std::wstring label = toWide(item.name);
-            const AString shortcutText = item.shortcut.toString();
-            if (!shortcutText.empty()) {
-                label.push_back(L'\t');
-                label += toWide(shortcutText);
+            if (!item.shortcut.empty()) {
+                const AString shortcutText = static_cast<AString>(item.shortcut);
+                if (!shortcutText.empty()) {
+                    label.push_back(L'\t');
+                    label += toWide(shortcutText);
+                }
             }
 
             UINT flags = MF_STRING;
@@ -167,8 +169,10 @@ void Win32MenuProvider::createMenu(const AVector<AMenuItem>& vector) {
     GetCursorPos(&pt);
 
     HWND hwnd = nullptr;
-    if (auto* win = AWindow::current()) {
-        hwnd = win->nativeHandle();
+    if (auto* base = AWindow::current()) {
+        if (auto* win = dynamic_cast<AWindow*>(base)) {
+            hwnd = win->getNativeHandle();
+        }
     }
 
     mOpen = true;

--- a/aui.views/src/AUI/Platform/win32/Win32MenuProvider.cpp
+++ b/aui.views/src/AUI/Platform/win32/Win32MenuProvider.cpp
@@ -1,0 +1,200 @@
+/*
+ * AUI Framework - Declarative UI toolkit for modern C++20
+ * Copyright (C) 2020-2025 Alex2772 and Contributors
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#include "Win32MenuProvider.h"
+#include <AUI/Action/AMenu.h>
+#include <AUI/Action/AShortcut.h>
+#include <AUI/Image/IDrawable.h>
+#include <AUI/Image/AImage.h>
+#include <AUI/Platform/AWindow.h>
+
+#include <windows.h>
+
+#include <cstring>
+#include <functional>
+#include <unordered_map>
+#include <vector>
+
+namespace {
+
+// Ids start at 1 — ID 0 from TrackPopupMenuEx means "cancelled".
+constexpr UINT kFirstMenuId = 1;
+
+// Owned resources for one popup lifetime: id→callback map + accumulated HBITMAPs
+// (for icons) + HMENUs (root + all submenus), all destroyed after the modal call returns.
+struct MenuResources {
+    std::unordered_map<UINT, std::function<void()>> callbacks;
+    std::vector<HBITMAP> bitmaps;
+    std::vector<HMENU> menus;
+    UINT nextId = kFirstMenuId;
+
+    ~MenuResources() {
+        for (HBITMAP hbmp : bitmaps) DeleteObject(hbmp);
+        // The root HMENU destroys its own submenus cascade-style; we only need to
+        // destroy root menus (tracked as the first entry in `menus`).
+        if (!menus.empty()) DestroyMenu(menus.front());
+    }
+};
+
+std::wstring toWide(const AString& s) {
+    const std::string utf8 = s.toStdString();
+    if (utf8.empty()) return {};
+    const int wlen = MultiByteToWideChar(CP_UTF8, 0, utf8.data(), int(utf8.size()), nullptr, 0);
+    std::wstring wide(wlen, L'\0');
+    MultiByteToWideChar(CP_UTF8, 0, utf8.data(), int(utf8.size()), wide.data(), wlen);
+    return wide;
+}
+
+// Convert AUI IDrawable to a pre-multiplied BGRA HBITMAP at 16×16 physical px —
+// the classic Win32 menu icon size. DWM composites this correctly on Vista+.
+HBITMAP drawableToHBITMAP(const _<IDrawable>& drawable) {
+    if (!drawable) return nullptr;
+    const glm::ivec2 size { 16, 16 };
+    AImage rasterized = drawable->rasterize(size);
+    const auto src = rasterized.buffer();
+    if (src.empty()) return nullptr;
+
+    const int w = rasterized.width();
+    const int h = rasterized.height();
+    const int bytesPerRow = w * 4;
+    if (int(src.size()) < bytesPerRow * h) return nullptr;
+
+    BITMAPINFO bmi {};
+    bmi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
+    bmi.bmiHeader.biWidth = w;
+    bmi.bmiHeader.biHeight = -h;   // negative = top-down rows (AUI stores top-down)
+    bmi.bmiHeader.biPlanes = 1;
+    bmi.bmiHeader.biBitCount = 32;
+    bmi.bmiHeader.biCompression = BI_RGB;
+
+    void* pixels = nullptr;
+    HBITMAP hbmp = CreateDIBSection(nullptr, &bmi, DIB_RGB_COLORS, &pixels, nullptr, 0);
+    if (!hbmp || !pixels) return nullptr;
+
+    // AUI is RGBA; Win32 DIBs are BGRA — swizzle & pre-multiply alpha in one pass.
+    const std::uint8_t* srcBytes = reinterpret_cast<const std::uint8_t*>(src.data());
+    std::uint8_t* dstBytes = static_cast<std::uint8_t*>(pixels);
+    for (int i = 0; i < w * h; ++i) {
+        const std::uint8_t r = srcBytes[i * 4 + 0];
+        const std::uint8_t g = srcBytes[i * 4 + 1];
+        const std::uint8_t b = srcBytes[i * 4 + 2];
+        const std::uint8_t a = srcBytes[i * 4 + 3];
+        dstBytes[i * 4 + 0] = std::uint8_t((int(b) * a + 127) / 255);
+        dstBytes[i * 4 + 1] = std::uint8_t((int(g) * a + 127) / 255);
+        dstBytes[i * 4 + 2] = std::uint8_t((int(r) * a + 127) / 255);
+        dstBytes[i * 4 + 3] = a;
+    }
+    return hbmp;
+}
+
+HMENU buildMenu(const AVector<AMenuItem>& items, MenuResources& res);
+
+void appendItem(HMENU parent, const AMenuItem& item, MenuResources& res) {
+    switch (item.type) {
+        case AMenu::SEPARATOR: {
+            AppendMenuW(parent, MF_SEPARATOR, 0, nullptr);
+            break;
+        }
+        case AMenu::SUBLIST: {
+            HMENU sub = buildMenu(item.subItems, res);
+            UINT flags = MF_POPUP | MF_STRING;
+            if (!item.enabled) flags |= MF_GRAYED;
+            AppendMenuW(parent, flags, reinterpret_cast<UINT_PTR>(sub), toWide(item.name).c_str());
+            break;
+        }
+        case AMenu::SINGLE: {
+            const UINT id = res.nextId++;
+            res.callbacks.emplace(id, item.onAction);
+
+            // Win32 auto-right-aligns anything after a tab character.
+            std::wstring label = toWide(item.name);
+            const AString shortcutText = item.shortcut.toString();
+            if (!shortcutText.empty()) {
+                label.push_back(L'\t');
+                label += toWide(shortcutText);
+            }
+
+            UINT flags = MF_STRING;
+            if (!item.enabled) flags |= MF_GRAYED;
+            AppendMenuW(parent, flags, id, label.c_str());
+
+            if (HBITMAP hbmp = drawableToHBITMAP(item.icon)) {
+                res.bitmaps.push_back(hbmp);
+                MENUITEMINFOW mii {};
+                mii.cbSize = sizeof(mii);
+                mii.fMask = MIIM_BITMAP;
+                mii.hbmpItem = hbmp;
+                SetMenuItemInfoW(parent, id, FALSE, &mii);
+            }
+            break;
+        }
+    }
+}
+
+HMENU buildMenu(const AVector<AMenuItem>& items, MenuResources& res) {
+    HMENU menu = CreatePopupMenu();
+    res.menus.push_back(menu);
+    for (const auto& item : items) {
+        appendItem(menu, item, res);
+    }
+    return menu;
+}
+
+}   // namespace
+
+Win32MenuProvider::Win32MenuProvider() = default;
+
+Win32MenuProvider::~Win32MenuProvider() {
+    closeMenu();
+}
+
+void Win32MenuProvider::createMenu(const AVector<AMenuItem>& vector) {
+    closeMenu();
+
+    MenuResources res;
+    HMENU root = buildMenu(vector, res);
+    if (!root) return;
+
+    POINT pt {};
+    GetCursorPos(&pt);
+
+    HWND hwnd = nullptr;
+    if (auto* win = AWindow::current()) {
+        hwnd = win->nativeHandle();
+    }
+
+    mOpen = true;
+    const BOOL cmd = TrackPopupMenuEx(
+        root,
+        TPM_RETURNCMD | TPM_RIGHTBUTTON | TPM_LEFTALIGN | TPM_TOPALIGN,
+        pt.x, pt.y,
+        hwnd,
+        nullptr);
+    mOpen = false;
+
+    if (cmd != 0) {
+        const auto it = res.callbacks.find(UINT(cmd));
+        if (it != res.callbacks.end() && it->second) {
+            it->second();
+        }
+    }
+    // res destructor cleans up HMENU + HBITMAPs.
+}
+
+void Win32MenuProvider::closeMenu() {
+    if (mOpen) {
+        EndMenu();   // unblock the modal TrackPopupMenuEx; createMenu will finish cleanup.
+    }
+}
+
+bool Win32MenuProvider::isOpen() {
+    return mOpen;
+}

--- a/aui.views/src/AUI/Platform/win32/Win32MenuProvider.h
+++ b/aui.views/src/AUI/Platform/win32/Win32MenuProvider.h
@@ -1,0 +1,34 @@
+/*
+ * AUI Framework - Declarative UI toolkit for modern C++20
+ * Copyright (C) 2020-2025 Alex2772 and Contributors
+ *
+ * SPDX-License-Identifier: MPL-2.0
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+#pragma once
+
+#include <AUI/Action/MenuProvider/IMenuProvider.h>
+
+/**
+ * @brief Native Win32 context-menu provider.
+ * @details
+ * Builds an HMENU tree from an AMenuModel and displays it via `TrackPopupMenuEx`.
+ * Produces Windows 11 fluent appearance, dark-mode awareness, system accent colors,
+ * keyboard navigation, and Narrator integration for free.
+ */
+class API_AUI_VIEWS Win32MenuProvider : public IMenuProvider {
+public:
+    Win32MenuProvider();
+    ~Win32MenuProvider() override;
+
+    void createMenu(const AVector<AMenuItem>& vector) override;
+    void closeMenu() override;
+    bool isOpen() override;
+
+private:
+    bool mOpen = false;
+};


### PR DESCRIPTION
Hey @Alex2772 

I've made some changes to aui.views while working on my app. These changes focus on cross-platform consistency, and platform-specific integrations.

### Changes

- Per-platform custom caption windows — `CustomCaptionWindowImpl` split into Win32/macOS/Linux implementations selected at compile time; `ACustomCaptionWindow` gains a title label on macOS, plus `AWindow*` parent and `WindowStyle` constructor parameters.
- New `WindowStyle::NO_TITLEBAR` — hides the OS titlebar while keeping native min/max/close controls. Win32: `WM_NCCALCSIZE`/`WM_NCHITTEST` handlers + `DwmExtendFrameIntoClientArea` (Win11 snap-layout flyouts keep working). macOS: `FullSizeContentView` with transparent titlebar; traffic lights preserved for `NO_TITLEBAR`, hidden for `NO_DECORATORS`. `NO_RESIZE` and `NO_MINIMIZE_MAXIMIZE` are now honored on both.
- Opt-in native context menus — new `MacOSMenuProvider` (NSMenu) and `Win32MenuProvider` (HMENU/TrackPopupMenuEx). `AMenu::setUseSystemMenus(true)` opts in; `AMenu::setGlobalProvider()` installs a custom provider. Currently no-op on Linux... Menu items now support `_<IDrawable>` icon, rendered in AUI-drawn menus too (`.menu-item-icon` style added).
- macOS windowing fixes — SYS windows become real popups (borderless, `NSPopUpMenuWindowLevel`, hide-on-deactivate); getWindowPosition/setGeometry/moveToCenter implemented with proper AppKit↔AUI coordinate and DPI conversion;
- Surface lifetime fix — ASurface destructor now closes attached overlapping surfaces (menus, dropdowns, tooltips).

### Previous behavior

- ACustomCaptionWindow always used the Win32 implementation, even on macOS/Linux.
- macOS setWindowStyle(SYS) was effectively a no-op (implementation commented out); getWindowPosition() returned {0, 0}; setGeometry/moveToCenter only moved the AUI view, not the native window.
- Clicking a background window while a popup was open only activated the window — the click was swallowed and the popup stayed open.
- Menus were always AUI-drawn with no way to use native menus and no icon support.
- Destroying a window with open overlapping surfaces left them dangling.

### New behavior

- Each platform gets its own caption implementation; macOS keeps native traffic lights, Linux uses full CSD with _NET_WM_MOVERESIZE drag.
- NO_TITLEBAR gives a frameless-looking window that retains OS-drawn caption buttons and native drag/snap behavior.
- macOS windows report and accept real geometry, center correctly, and deliver first clicks so popups close as expected.
- Apps can opt into fully native menus (with accessibility integration) via one call, and menu items can carry icons on all providers.
- Overlapping surfaces are reliably closed with their owner window.

### Screenshots

These screenshots are from my revamp of the Amplitude Studio app:

- NO_DECORATORS now respects the MacOS window shape while removing titlebar and traffic-lights:
<img width="712" height="512" alt="Screenshot 2026-09-04 at 16 42 06" src="https://github.com/user-attachments/assets/696a92c8-315c-44a7-b19b-c427aaf4ce11" />

- AUI-drawn custom title bar while traffic lights are kept, using the new NO_TITLEBAR semantic (honoring other semantics such as NO_MINIMIZE_MAXIMIZE):
<img width="835" height="135" alt="image" src="https://github.com/user-attachments/assets/ce41e81a-c395-4ec0-85fa-d387899d2f24" />
<img width="835" height="135" alt="image" src="https://github.com/user-attachments/assets/2b0e63f8-8d82-479b-aff0-36222dbbef51" />

- Native context menu VS AUI-drawn context menu:
<img width="322" height="265" alt="Screenshot 2026-09-04 at 16 50 20" src="https://github.com/user-attachments/assets/96b2176e-ad6d-4071-a97c-edab2cc84fb4" />
<img width="326" height="251" alt="Screenshot 2026-09-04 at 16 52 25" src="https://github.com/user-attachments/assets/5d901f0a-4c72-4e07-8a81-479235f8f90c" />

### Concerns

As I'm not a X11/Wayland API master, I mostly used AI and web searches to implement the Linux side of the provided features, but unfortunately was not able to test, because the last time I tried, I got an issue with an AUI.boot package and didn't have the time to dig in it. I may only able to test again in few weeks.